### PR TITLE
Move auth logic to proxy

### DIFF
--- a/src/lib/session.tsx
+++ b/src/lib/session.tsx
@@ -33,8 +33,7 @@ import { Session } from "@supabase/supabase-js";
  * @see {@link https://supabase.com/docs/guides/auth} for Supabase auth details.
  * @since 1.0.0
  */
-export function useAuth() {
-  const router = useRouter();
+export function useSession() {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -51,31 +50,18 @@ export function useAuth() {
     } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session);
       setLoading(false);
-
-      // Redirect to login if session is lost on a protected route
-      if (!session) {
-        router.push("/login");
-      }
     });
-
     return () => subscription.unsubscribe();
-  }, [router]);
+  }, []);
 
   return { session, loading };
 }
 
-export function withAuth<P extends object>(
+export function withSession<P extends object>(
   WrappedComponent: React.ComponentType<P>,
 ) {
   return function ProtectedRoute(props: P) {
-    const router = useRouter();
-    const { session, loading } = useAuth();
-
-    useEffect(() => {
-      if (!loading && !session) {
-        router.push("/login");
-      }
-    }, [loading, session, router]);
+    const { session, loading } = useSession();
 
     if (loading) {
       return (
@@ -105,7 +91,7 @@ export function withAuth<P extends object>(
     }
 
     if (!session) {
-      return null; // or a custom loading/redirecting UI
+      return null; // proxy should prevent this and redirect to login
     }
 
     return <WrappedComponent {...props} session={session} />;

--- a/src/lib/session.tsx
+++ b/src/lib/session.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import { Session } from "@supabase/supabase-js";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { supabase } from "@/lib/supabaseClient";
-import { withAuth } from "@/lib/auth";
+import { withSession } from "@/lib/session";
 import { Session } from "@supabase/supabase-js/dist/index.cjs";
 
 function Home({ session }: { session: Session }) {
@@ -139,4 +139,4 @@ function Home({ session }: { session: Session }) {
   );
 }
 
-export default withAuth(Home);
+export default withSession(Home);

--- a/src/pages/settings/village-codes.tsx
+++ b/src/pages/settings/village-codes.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { trpc } from "@/utils/trpc";
-import { withAuth } from "@/lib/auth";
+import { withSession } from "@/lib/session";
 import { VillageCode, NewVillageCode } from "@/db/schema";
 import Link from "next/link";
 
@@ -317,4 +317,4 @@ function VillageCodesPage() {
   );
 }
 
-export default withAuth(VillageCodesPage);
+export default withSession(VillageCodesPage);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { url } from "zod/v4/mini";
 
 /**
  * Middleware to refresh Supabase auth session.
@@ -42,10 +43,31 @@ export async function proxy(request: NextRequest) {
   });
 
   // IMPORTANT: Do not run any Supabase logic between createServerClient and
-  // supabase.auth.getUser(). A simple mistake could make your app insecure.
+  // supabase.auth.getUser(). A simple mistake could make the app insecure.
 
-  // This will refresh the session if expired and set cookies
-  await supabase.auth.getUser();
+  // get user
+  const {
+    data: { user },
+  } = await supabase.auth.getUser(); // This will also refresh the session if expired and set cookies
+
+
+  // Redirect logic:
+  const { pathname } = new URL(request.url);
+  const isLoginRoute = pathname === "/login";
+
+  // If NOT logged in and NOT on /login → force to /login
+  if (!user && !isLoginRoute) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirectTo", pathname + request.url.search);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // If logged in and trying to hit /login → send to main app
+  if (user && isLoginRoute) {
+    const dashboardUrl = new URL("/", request.url);
+    return NextResponse.redirect(dashboardUrl);
+  }
+
 
   return supabaseResponse;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import { url } from "zod/v4/mini";
 
 /**
  * Middleware to refresh Supabase auth session.
@@ -50,7 +49,6 @@ export async function proxy(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser(); // This will also refresh the session if expired and set cookies
 
-
   // Redirect logic:
   const { pathname } = new URL(request.url);
   const isLoginRoute = pathname === "/login";
@@ -67,7 +65,6 @@ export async function proxy(request: NextRequest) {
     const dashboardUrl = new URL("/", request.url);
     return NextResponse.redirect(dashboardUrl);
   }
-
 
   return supabaseResponse;
 }


### PR DESCRIPTION
This PR moves our auth model from primarily client-side protection to a server-side, proxy-based guard for the entire app (with `/login` as the only public route).

Previously, we relied on a `withAuth` HOC and `useAuth` hook to protect pages in the browser. Each protected page rendered on the client, then ran Supabase `getSession()` and `onAuthStateChange` to decide whether to redirect to `/login`. This worked functionally, but it meant that:

- The server would still send HTML for protected routes before we knew if the user was authenticated.
- Route protection logic was split across client and server, which made reasoning about access a bit harder.
- We were doing extra auth work on the client that we could handle once centrally.

With this PR, we’ve upgraded `proxy.ts` so it now both refreshes the Supabase session **and** enforces route-level access at the edge. On every request, the proxy:

- Creates a Supabase server client from the incoming cookies.
- Calls `supabase.auth.getUser()` to transparently refresh tokens and update cookies.
- Treats all routes as protected by default, except `/login`.
- Redirects unauthenticated users hitting any non-`/login` path to `/login`, preserving the intended destination in a `redirectTo` query param.
- Redirects authenticated users away from `/login` to `/dashboard`, so they don’t see the login screen when already signed in.

The main benefit is that our access control is now enforced before any protected page or data is rendered, which is a better fit for a patient-facing system. We have a single, central place (the proxy) that defines what “authenticated” means and which routes are reachable in each state. The client-side auth utilities can be simplified to focus on UX (showing the current user, reacting to sign-outs, etc.) rather than acting as the primary security boundary.