### PR TITLE
Add Vitals Page with Navigation and Basic Layout

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumbs({ items }: BreadcrumbsProps) {
+  return (
+    <nav className="flex items-center gap-2 text-sm mb-6">
+      {items.map((item, index) => (
+        <div key={index} className="flex items-center gap-2">
+          {item.href ? (
+            <Link
+              href={item.href}
+              className="text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              {item.label}
+            </Link>
+          ) : (
+            <span className="text-slate-900 font-medium">{item.label}</span>
+          )}
+          {index < items.length - 1 && (
+            <svg
+              className="h-4 w-4 text-slate-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M8.25 4.5l7.5 7.5-7.5 7.5"
+              />
+            </svg>
+          )}
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/LogoTitle.tsx
+++ b/src/components/LogoTitle.tsx
@@ -11,7 +11,12 @@ export default function LogoTitle({
   return (
     <div className={clsx("flex flex-row h-min items-center gap-2", className)}>
       <SabaiLogo />
-      <span className={clsx("text-2xl font-extrabold", textClassName)}>
+      <span
+        className={clsx(
+          "text-2xl font-extrabold text-neutral-100",
+          textClassName,
+        )}
+      >
         Project Sa&apos;bai
       </span>
     </div>

--- a/src/components/interactive/PatientSearchResultItem.tsx
+++ b/src/components/interactive/PatientSearchResultItem.tsx
@@ -6,15 +6,17 @@ import { PatientsRouterListItem } from "@/utils/trpc-types";
 interface PatientSearchResultItemProps {
   patient: PatientsRouterListItem;
   onSelect: () => void;
+  linkPath?: string;
 }
 
 export default function PatientSearchResultItem({
   patient,
   onSelect,
+  linkPath = `/patient/${patient.id}`,
 }: PatientSearchResultItemProps) {
   return (
     <Link
-      href={`/patient/${patient.id}`}
+      href={linkPath}
       onClick={onSelect}
       className="flex items-center gap-3 text-sm text-neutral-700 px-2 py-2 rounded bg-white border border-neutral-100 hover:bg-neutral-75"
     >

--- a/src/components/interactive/PatientSearchResults.tsx
+++ b/src/components/interactive/PatientSearchResults.tsx
@@ -7,6 +7,7 @@ interface PatientSearchResultsProps {
   isLoading: boolean;
   isRefetching: boolean;
   onSelect: () => void;
+  getPatientLink?: (patientId: number) => string;
 }
 
 export default function PatientSearchResults({
@@ -15,6 +16,7 @@ export default function PatientSearchResults({
   isLoading,
   isRefetching,
   onSelect,
+  getPatientLink,
 }: PatientSearchResultsProps) {
   // const debouncedSearchText = useDebounce(searchText, 300);
   if (searchText.trim() === "") {
@@ -34,6 +36,7 @@ export default function PatientSearchResults({
               key={patient.id}
               patient={patient}
               onSelect={onSelect}
+              linkPath={getPatientLink?.(patient.id)}
             />
           ))}
         </div>

--- a/src/components/layouts/PatientTopMenuLayout.tsx
+++ b/src/components/layouts/PatientTopMenuLayout.tsx
@@ -6,10 +6,12 @@ import useDebounce from "@/hooks/useDebounce";
 
 interface PatientTopMenuLayoutProps {
   children: ReactNode;
+  getPatientLink?: (patientId: number) => string;
 }
 
 export default function PatientTopMenuLayout({
   children,
+  getPatientLink,
 }: PatientTopMenuLayoutProps) {
   const [searchText, setSearchText] = useState("");
   const debouncedSearchText = useDebounce(searchText, 300);
@@ -49,6 +51,7 @@ export default function PatientTopMenuLayout({
             isLoading={isLoading}
             isRefetching={isRefetching}
             onSelect={() => setSearchText("")}
+            getPatientLink={getPatientLink}
           />
         </div>
       </div>

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -19,7 +19,7 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
   return (
     <div className="flex h-screen flex-col sm:flex-row">
       {/* mobile sidebar */}
-      <div className="flex sm:hidden flex-row w-full p-2 justify-between items-center bg-navbar">
+      <div className="flex sm:hidden flex-row w-full p-2 justify-between items-center bg-[var(--color-navbar)]">
         <SabaiLogo />
         <button
           className={`group flex items-center gap-2 p-2 pl-4 rounded-md hover:cursor-pointer`}
@@ -34,7 +34,7 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
         <SidebarNavButtons />
       </div>
       {/* desktop sidebar */}
-      <div className="hidden sm:flex flex-col min-w-64 p-2 gap-6 bg-navbar">
+      <div className="hidden sm:flex flex-col min-w-64 p-2 gap-6 bg-[var(--color-navbar)]">
         <LogoTitle className="m-2" />
         <SidebarNavButtons />
       </div>

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { ReactNode, useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import { AiOutlineSetting, AiOutlineUser } from "react-icons/ai";
+import { MdMonitorHeart } from "react-icons/md";
 import { PiSignOutFill } from "react-icons/pi";
 import { IoMdMenu } from "react-icons/io";
 import { LuScanFace } from "react-icons/lu";
@@ -55,6 +56,7 @@ function SidebarNavButtons() {
   const navigation = [
     { name: "Scan Face", href: "/scanFace", icon: LuScanFace },
     { name: "Patient", href: "/patient", icon: AiOutlineUser },
+    { name: "Vitals", href: "/vitals", icon: MdMonitorHeart },
     {
       name: "Settings",
       href: "/settings/village-codes",

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -19,7 +19,7 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
   return (
     <div className="flex h-screen flex-col sm:flex-row">
       {/* mobile sidebar */}
-      <div className="flex sm:hidden flex-row w-full p-2 justify-between items-center bg-neutral-200">
+      <div className="flex sm:hidden flex-row w-full p-2 justify-between items-center bg-navbar">
         <SabaiLogo />
         <button
           className={`group flex items-center gap-2 p-2 pl-4 rounded-md hover:cursor-pointer`}
@@ -34,7 +34,7 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
         <SidebarNavButtons />
       </div>
       {/* desktop sidebar */}
-      <div className="hidden sm:flex flex-col min-w-64 p-2 gap-6 bg-neutral-50">
+      <div className="hidden sm:flex flex-col min-w-64 p-2 gap-6 bg-navbar">
         <LogoTitle className="m-2" />
         <SidebarNavButtons />
       </div>

--- a/src/pages/patient/index.tsx
+++ b/src/pages/patient/index.tsx
@@ -1,6 +1,5 @@
 import PatientTopMenuLayout from "@/components/layouts/PatientTopMenuLayout";
 import { trpc } from "@/utils/trpc";
-import Link from "next/link";
 import { PatientPhoto } from "@/components/PatientPhoto";
 import withDefaultLayout from "@/components/layouts/withDefaultLayout";
 import Breadcrumbs from "@/components/Breadcrumbs";

--- a/src/pages/patient/index.tsx
+++ b/src/pages/patient/index.tsx
@@ -3,6 +3,7 @@ import { trpc } from "@/utils/trpc";
 import Link from "next/link";
 import { PatientPhoto } from "@/components/PatientPhoto";
 import withDefaultLayout from "@/components/layouts/withDefaultLayout";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 function PatientsBasePage() {
   // 1. Fetch data
@@ -11,29 +12,9 @@ function PatientsBasePage() {
   return (
     <div className="min-h-screen flex-1 p-8">
       <div className="w-full mx-auto">
-        {/* Navigation / Breadcrumbs */}
-        <nav className="flex items-center gap-2 text-sm mb-6">
-          <Link
-            href="/"
-            className="text-slate-500 hover:text-slate-700 transition-colors"
-          >
-            Home
-          </Link>
-          <svg
-            className="h-4 w-4 text-slate-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8.25 4.5l7.5 7.5-7.5 7.5"
-            />
-          </svg>
-          <span className="text-slate-900 font-medium">Patients</span>
-        </nav>
+        <Breadcrumbs
+          items={[{ label: "Home", href: "/" }, { label: "Patients" }]}
+        />
 
         {/* Header */}
         <div className="flex justify-between items-center mb-8">

--- a/src/pages/settings/village-codes.tsx
+++ b/src/pages/settings/village-codes.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { trpc } from "@/utils/trpc";
 import { VillageCode, NewVillageCode } from "@/db/schema";
-import Link from "next/link";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
 const DEFAULT_FORM: NewVillageCode = {

--- a/src/pages/settings/village-codes.tsx
+++ b/src/pages/settings/village-codes.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { trpc } from "@/utils/trpc";
 import { VillageCode, NewVillageCode } from "@/db/schema";
 import Link from "next/link";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 const DEFAULT_FORM: NewVillageCode = {
   code: "",
@@ -80,43 +81,13 @@ function VillageCodesPage() {
   return (
     <div className="min-h-screen bg-slate-50 p-8">
       <div className="max-w-5xl mx-auto">
-        {/* Breadcrumbs */}
-        <nav className="flex items-center gap-2 text-sm mb-6">
-          <Link
-            href="/"
-            className="text-slate-500 hover:text-slate-700 transition-colors"
-          >
-            Home
-          </Link>
-          <svg
-            className="h-4 w-4 text-slate-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8.25 4.5l7.5 7.5-7.5 7.5"
-            />
-          </svg>
-          <span className="text-slate-500">Settings</span>
-          <svg
-            className="h-4 w-4 text-slate-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8.25 4.5l7.5 7.5-7.5 7.5"
-            />
-          </svg>
-          <span className="text-slate-900 font-medium">Village Codes</span>
-        </nav>
+        <Breadcrumbs
+          items={[
+            { label: "Home", href: "/" },
+            { label: "Settings" },
+            { label: "Village Codes" },
+          ]}
+        />
 
         <div className="flex justify-between items-center mb-8">
           <h1 className="text-3xl font-bold text-slate-900">Village Codes</h1>

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from "next/router";
+import withDefaultLayout from "@/components/layouts/withDefaultLayout";
+import PatientTopMenuLayout from "@/components/layouts/PatientTopMenuLayout";
+
+export default function PatientVitalsPage() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  return (
+    <div className="min-h-screen flex-1 p-8">
+      <div className="w-full mx-auto">
+        <div className="flex-1 overflow-y-auto p-6">
+          <h1 className="text-2xl font-bold mb-4">Patient Vitals - ID: {id}</h1>
+          <p className="text-gray-600 mb-6">Vital signs for patient {id}.</p>
+
+          <div className="bg-white rounded-lg shadow p-4">
+            <p className="text-gray-500">
+              Patient vitals content will go here.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+PatientVitalsPage.getLayout = (page: React.ReactNode) =>
+  withDefaultLayout(
+    <PatientTopMenuLayout getPatientLink={(id) => `/vitals/${id}`}>
+      {page}
+    </PatientTopMenuLayout>,
+  );

--- a/src/pages/vitals/index.tsx
+++ b/src/pages/vitals/index.tsx
@@ -1,0 +1,31 @@
+import withDefaultLayout from "@/components/layouts/withDefaultLayout";
+import PatientTopMenuLayout from "@/components/layouts/PatientTopMenuLayout";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+export default function VitalsPage() {
+  return (
+    <div className="min-h-screen flex-1 p-8">
+      <div className="w-full mx-auto">
+        <Breadcrumbs
+          items={[{ label: "Home", href: "/" }, { label: "Vitals" }]}
+        />
+        {/* Header for Vitals */}
+        <div className="flex justify-between items-center mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-slate-900">Vitals</h1>
+            <p className="mt-2 text-slate-600">
+              Manage patient vital signs here.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+VitalsPage.getLayout = (page: React.ReactNode) =>
+  withDefaultLayout(
+    <PatientTopMenuLayout getPatientLink={(id) => `/vitals/${id}`}>
+      {page}
+    </PatientTopMenuLayout>,
+  );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -59,6 +59,9 @@
   --color-info-subtle: oklch(0.95 0.04 260);
 
   --color-highlight: oklch(1 0.1 85);
+
+  /* Custom navbar color */
+  --color-navbar: #101727;
 }
 
 .dark {
@@ -106,6 +109,9 @@
   --color-info-subtle: oklch(0.22 0.05 260);
 
   --color-highlight: oklch(0.85 0.12 85);
+
+  /* Custom navbar color */
+  --color-navbar: #101727;
 }
 
 body {


### PR DESCRIPTION
## Problem

The vitals page structure and navigation was not set up. With this set up of barebone vitals pages, team can move forward to implement vitals schema and form fields on the pages on the respective pages.

Closes #59 

## Solution
- Added "Vitals" navigation item to sidebar in SidebarLayout.tsx
- Created vitals index page (`/pages/vitals/index.tsx`) with basic layout using existing components
- Created individual vitals page (/pages/vitals/[id]/index.tsx) with patient-specific context
- refactored existing pages (`patient/index.tsx`, `settings/village-codes.tsx`) to use shared breadcrumb component

## Breaking changes
❌ No - this PR is backwards compatible. All existing functionality remains unchanged

## Tests
  1. Run the frontend locally
  2. Navigate to sidebar and confirm "Vitals" appears in navigation
  3. Click on Vitals to access `/vitals` page - confirm it renders with proper layout (though layout is pretty barebone as of now)
  4. Navigate to `/vitals/[patient-id]` and confirm patient-specific vitals page renders (also confirm that it does not show individual patient detail page)
  5. Verify breadcrumb navigation works correctly on all vitals pages

## Future Notes / TODOs
Future PRs will prob add:
- Vitals data schema and models
- Form fields and validation
- Vitals-specific UI components (if any are relevant)

