### PR TITLE
Fix/cloudinary url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,7 @@ SUPABASE_SECRET_KEY=your-secret-key-here
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 
 # CLOUDINARY
-CLOUDINARY_URL_PREFIX=your_cloudinary_url_prefix # prefix for image links
-CLOUDINARY_URL=cloudinary://API_KEY:API_SECRET@CLOUD_NAME # for cloudinary API 
+# Base URL for serving images: https://res.cloudinary.com/YOUR_CLOUD_NAME/
+CLOUDINARY_URL_PREFIX=https://res.cloudinary.com/your-cloud-name/
+# API credentials: cloudinary://API_KEY:API_SECRET@CLOUD_NAME
+CLOUDINARY_URL=cloudinary://123456789012345:abcdefghijklmnopqrstuvwxyz123456@your-cloud-name 

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 
 # CLOUDINARY
 # Base URL for serving images: https://res.cloudinary.com/YOUR_CLOUD_NAME/
-CLOUDINARY_URL_PREFIX=https://res.cloudinary.com/your-cloud-name/
+CLOUDINARY_URL_PREFIX=https://res.cloudinary.com/your-cloud-name
 # API credentials: cloudinary://API_KEY:API_SECRET@CLOUD_NAME
 CLOUDINARY_URL=cloudinary://123456789012345:abcdefghijklmnopqrstuvwxyz123456@your-cloud-name 

--- a/src/server/utils/cloudinary.ts
+++ b/src/server/utils/cloudinary.ts
@@ -20,7 +20,3 @@ export async function uploadToCloudinary(image: File) {
 
   return `image/upload/v${uploaded.version}/${uploaded.public_id}`;
 }
-
-export async function deleteFromCloudinary(publicId: string) {
-  await cloudinary.uploader.destroy(publicId);
-}

--- a/src/server/utils/cloudinary.ts
+++ b/src/server/utils/cloudinary.ts
@@ -18,5 +18,12 @@ export async function uploadToCloudinary(image: File) {
       .end(buffer);
   });
 
-  return `image/upload/v${uploaded.version}/${uploaded.public_id}`;
+  return {
+    path: `v${uploaded.version}/${uploaded.public_id}`,
+    publicId: uploaded.public_id,
+  };
+}
+
+export async function deleteFromCloudinary(publicId: string) {
+  await cloudinary.uploader.destroy(publicId);
 }

--- a/src/server/utils/cloudinary.ts
+++ b/src/server/utils/cloudinary.ts
@@ -18,7 +18,7 @@ export async function uploadToCloudinary(image: File) {
       .end(buffer);
   });
 
-  return `v${uploaded.version}/${uploaded.public_id}`;
+  return `image/upload/v${uploaded.version}/${uploaded.public_id}`;
 }
 
 export async function deleteFromCloudinary(publicId: string) {

--- a/src/server/utils/cloudinary.ts
+++ b/src/server/utils/cloudinary.ts
@@ -18,10 +18,7 @@ export async function uploadToCloudinary(image: File) {
       .end(buffer);
   });
 
-  return {
-    path: `v${uploaded.version}/${uploaded.public_id}`,
-    publicId: uploaded.public_id,
-  };
+  return `v${uploaded.version}/${uploaded.public_id}`;
 }
 
 export async function deleteFromCloudinary(publicId: string) {


### PR DESCRIPTION
## Problem

- The `uploadToCloudinary` function was returning URLs with incorrect format that included duplicated `image/upload` method, which could have caused issues when constructing the URLs

## Solution
- Fixed return value to only return the path portion without the duplicated `image/upload/` prefix

## Breaking Changes
- None, this is a bug fix

## Tests
- Fill up a dummy patient and capture photo, then head over to patients page to see if image gets rendered

## Future TODOs
- N.A.
