### PR TITLE
Fix column name for medication stock seed

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -143,7 +143,7 @@ export const medicationStock = pgTable("medication_stock", {
   quantity: integer("quantity").notNull().default(0),
   expiry: timestamp("expiry"),
   location: varchar("location", { length: 255 }),
-  stockStatus: medicationStatusEnum("state").default("active"),
+  stockStatus: medicationStatusEnum("stock_status").default("active"),
 });
 
 export type MedicationStock = typeof medicationStock.$inferSelect;

--- a/src/server/routers/medication_stock_router.ts
+++ b/src/server/routers/medication_stock_router.ts
@@ -14,7 +14,7 @@ export const medicationStockRouter = router({
         quantity: medicationStock.quantity,
         expiry: medicationStock.expiry,
         location: medicationStock.location,
-        state: medicationStock.stockStatus,
+        stock_status: medicationStock.stockStatus,
       })
       .from(medicationStock);
     return result;
@@ -27,7 +27,7 @@ export const medicationStockRouter = router({
         quantity: zfd.numeric(z.number().int()),
         expiry: zfd.text(z.coerce.date()),
         location: zfd.text(),
-        state: zfd.text(z.enum(medicationStatusEnum.enumValues)),
+        stock_status: zfd.text(z.enum(medicationStatusEnum.enumValues)),
       }),
     )
     .mutation(async ({ input }) => {
@@ -53,7 +53,7 @@ export const medicationStockRouter = router({
       return { success: !!result };
     }),
 
-  // id, quantity, expiry, location, state
+  // id, quantity, expiry, location, stock_status
   update: protectedProcedure
     .input(
       zfd.formData({
@@ -62,7 +62,7 @@ export const medicationStockRouter = router({
         quantity: zfd.numeric(z.number().int().optional()),
         expiry: zfd.text(z.coerce.date().optional()),
         location: zfd.text(z.string().optional()),
-        state: zfd.text(z.enum(medicationStatusEnum.enumValues).optional()),
+        stock_status: zfd.text(z.enum(medicationStatusEnum.enumValues).optional()),
       }),
     )
     .mutation(async ({ input }) => {

--- a/src/server/routers/medication_stock_router.ts
+++ b/src/server/routers/medication_stock_router.ts
@@ -14,7 +14,7 @@ export const medicationStockRouter = router({
         quantity: medicationStock.quantity,
         expiry: medicationStock.expiry,
         location: medicationStock.location,
-        stock_status: medicationStock.stockStatus,
+        stockStatus: medicationStock.stockStatus,
       })
       .from(medicationStock);
     return result;
@@ -27,7 +27,7 @@ export const medicationStockRouter = router({
         quantity: zfd.numeric(z.number().int()),
         expiry: zfd.text(z.coerce.date()),
         location: zfd.text(),
-        stock_status: zfd.text(z.enum(medicationStatusEnum.enumValues)),
+        stockStatus: zfd.text(z.enum(medicationStatusEnum.enumValues)),
       }),
     )
     .mutation(async ({ input }) => {
@@ -62,7 +62,7 @@ export const medicationStockRouter = router({
         quantity: zfd.numeric(z.number().int().optional()),
         expiry: zfd.text(z.coerce.date().optional()),
         location: zfd.text(z.string().optional()),
-        stock_status: zfd.text(z.enum(medicationStatusEnum.enumValues).optional()),
+        stockStatus: zfd.text(z.enum(medicationStatusEnum.enumValues).optional()),
       }),
     )
     .mutation(async ({ input }) => {

--- a/supabase/seeds/04_medication_stock.sql
+++ b/supabase/seeds/04_medication_stock.sql
@@ -3,7 +3,7 @@ INSERT INTO medication_stock (
     quantity, 
     expiry, 
     location, 
-    state
+    stock_status
 ) VALUES
 (1, 200, '2026-12-31 00:00:00', 'Main Pharmacy Shelf A1', 'active'),
 (1, 150, '2026-06-30 00:00:00', 'Main Pharmacy Shelf A2', 'active'),


### PR DESCRIPTION
This PR:
- fixes the medication stock seed file as the column name wasn't changed after changing from `status` to `stock_status`.
- adds in the proper column name that was somehow lost when migration 4 was created (stashed somewhere possibly?) and thus not reflected correctly in the current code (current code in dev wrong, migration in dev correct, but now this code matches the code that was used to generate the correct migration)
- renames the column throughout the router as well for all methods