### PR TITLE
76 add use save on write hook

### DIFF
--- a/src/hooks/useSaveOnWrite.ts
+++ b/src/hooks/useSaveOnWrite.ts
@@ -1,0 +1,51 @@
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useEffectEvent,
+  useRef,
+} from "react";
+import useDebounce from "./useDebounce";
+
+export function useSaveOnWrite<T extends object>(
+  name: string,
+  initialValue: T,
+  dependencies: unknown[] = [],
+  debounceMs = 1000,
+): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
+  const storageKey =
+    dependencies.length > 0
+      ? `${name}_${dependencies.map((dep, index) => `dep${index + 1}=${dep}`).join("_")}`
+      : name;
+
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      return stored != null ? JSON.parse(stored) : initialValue;
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${storageKey}":`, error);
+      return initialValue;
+    }
+  });
+  const debouncedValue = useDebounce(value, debounceMs);
+
+  const saveToStorage = useEffectEvent(() => {
+    localStorage.setItem(storageKey, JSON.stringify(debouncedValue));
+  });
+
+  useEffect(() => {
+    saveToStorage();
+  }, [debouncedValue]);
+
+  const initialValueRef = useRef(initialValue);
+
+  const clear = useCallback(() => {
+    localStorage.removeItem(storageKey);
+    setValue(initialValueRef.current);
+  }, [storageKey]);
+
+  return [value, setValue, clear] as const;
+}

--- a/src/hooks/useSaveOnWrite.ts
+++ b/src/hooks/useSaveOnWrite.ts
@@ -13,10 +13,14 @@ export function useSaveOnWrite<T extends object>(
   dependencies: unknown[] = [],
   debounceMs = 1000,
 ): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
-  const storageKey =
-    dependencies.length > 0
+
+  function buildStorageKey(name: string, dependencies: unknown[]): string {
+    return dependencies.length > 0
       ? `${name}_${dependencies.map((dep, index) => `dep${index + 1}=${dep}`).join("_")}`
       : name;
+  }
+
+  const storageKey = buildStorageKey(name, dependencies);
 
   const [value, setValue] = useState<T>(() => {
     if (typeof window === "undefined") {

--- a/src/hooks/useSaveOnWrite.ts
+++ b/src/hooks/useSaveOnWrite.ts
@@ -7,13 +7,27 @@ import {
 } from "react";
 import useDebounce from "./useDebounce";
 
+/**
+ * Hook that manages state with automatic debounced localStorage persistence.
+ * @param name Storage key name
+ * @param initialValue Initial state value
+ * @param dependencies Optional dependencies for unique storage keys
+ * @param debounceMs Debounce delay in ms (default is 1000ms which is 1 second)
+ * @returns [value, setValue, clear]
+ */
 export function useSaveOnWrite<T extends object>(
   name: string,
   initialValue: T,
   dependencies: unknown[] = [],
   debounceMs = 1000,
 ): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
-
+  /**
+   * Builds a unique storage key by combining the base name with dependency values.
+   *
+   * @param name - The base storage key name
+   * @param dependencies - Array of dependency values to include in the key
+   * @returns The complete storage key string
+   */
   function buildStorageKey(name: string, dependencies: unknown[]): string {
     return dependencies.length > 0
       ? `${name}_${dependencies.map((dep, index) => `dep${index + 1}=${dep}`).join("_")}`
@@ -46,6 +60,9 @@ export function useSaveOnWrite<T extends object>(
 
   const initialValueRef = useRef(initialValue);
 
+  /**
+   * Clears the stored value from localStorage and resets the state to the initial value.
+   */
   const clear = useCallback(() => {
     localStorage.removeItem(storageKey);
     setValue(initialValueRef.current);

--- a/src/pages/settings/village-codes.tsx
+++ b/src/pages/settings/village-codes.tsx
@@ -23,7 +23,6 @@ function VillageCodesPage() {
     "village-codes-form",
     DEFAULT_FORM,
     [], // No dependencies
-    500, // 500ms debounce
   );
 
   // 2. Data Fetching

--- a/src/pages/settings/village-codes.tsx
+++ b/src/pages/settings/village-codes.tsx
@@ -79,7 +79,6 @@ function VillageCodesPage() {
 
   const closeForm = () => {
     setIsEditing(false);
-    setFormData(DEFAULT_FORM);
   };
 
   const handleDelete = (id: number) => {

--- a/src/pages/settings/village-codes.tsx
+++ b/src/pages/settings/village-codes.tsx
@@ -35,6 +35,7 @@ function VillageCodesPage() {
   const createMutation = trpc.villageCodesRouter.create.useMutation({
     onSuccess: () => {
       utils.villageCodesRouter.list.invalidate();
+      clearFormData();
       closeForm();
     },
   });
@@ -42,6 +43,7 @@ function VillageCodesPage() {
   const updateMutation = trpc.villageCodesRouter.update.useMutation({
     onSuccess: () => {
       utils.villageCodesRouter.list.invalidate();
+      clearFormData();
       closeForm();
     },
   });
@@ -77,7 +79,7 @@ function VillageCodesPage() {
 
   const closeForm = () => {
     setIsEditing(false);
-    clearFormData();
+    setFormData(DEFAULT_FORM);
   };
 
   const handleDelete = (id: number) => {

--- a/src/pages/settings/village-codes.tsx
+++ b/src/pages/settings/village-codes.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { trpc } from "@/utils/trpc";
+import { useSaveOnWrite } from "@/hooks/useSaveOnWrite";
 import { VillageCode, NewVillageCode } from "@/db/schema";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import TableHeader from "@/components/TableHeader";
@@ -18,7 +19,12 @@ function VillageCodesPage() {
   // 1. Local State
   const [showHidden, setShowHidden] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState<NewVillageCode>(DEFAULT_FORM);
+  const [formData, setFormData, clearFormData] = useSaveOnWrite<NewVillageCode>(
+    "village-codes-form",
+    DEFAULT_FORM,
+    [], // No dependencies
+    500, // 500ms debounce
+  );
 
   // 2. Data Fetching
   const utils = trpc.useUtils();
@@ -72,7 +78,7 @@ function VillageCodesPage() {
 
   const closeForm = () => {
     setIsEditing(false);
-    setFormData(DEFAULT_FORM);
+    clearFormData();
   };
 
   const handleDelete = (id: number) => {


### PR DESCRIPTION
Closes #76 

## Description

- Adds a new custom hook useSaveOnWrite that automatically persists component state to localStorage with debounced writes.

## Changes made
- Added useSaveOnWrite hook
- Added helper function buildStorageKey (to generate unique storage keys)
- Updated new village code modal to use hook (persist across page refreshes)