### PR TITLE
Fix config and module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "project-sabai",
   "version": "0.1.0",
+  "type": "module",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "node"],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
This PR fixes some unaddressed issues from a previous PR.

## How to replicate

- Switch to current `dev` branch
- run `pnpm seed:all` or `pnpm:seed:users` (anything that hits `ts-node supabase/scripts/seed-users.ts` will trigger the error)
- There is an error in the console ```TSError: ⨯ Unable to compile TypeScript:
supabase/scripts/seed-users.ts:9:48 - error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.```

## Why this happens

In `tsconfig.json`, the default value for the `types` attribute on the `compilerOptions` attribute is by default all visible `node_modules/@types`. By manually writing values, the default value was overridden causing `seed-users.ts` to throw an error because of the usage of `process.env`. 

TypeScript documentation: https://www.typescriptlang.org/tsconfig/#types

## Fix

The fix is just to manually include `node` in the types array. However, by doing this we encounter this error: 
```
(node:13220) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///.../project-sabai/supabase/scripts/seed-users.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
```

This is fixed by including `"type": "module"` in `package.json`. This shouldn't affect anything else since we're already using import and export syntax in the codebase.


