### PR TITLE
107 fix image capture resize

### DIFF
--- a/src/components/interactive/inputs/WebcamInput.tsx
+++ b/src/components/interactive/inputs/WebcamInput.tsx
@@ -22,13 +22,12 @@ export function WebcamInput({
   imageDetails,
   setImageDetails,
   cameraIsOpenCallback,
-  width = 250,
+  size = 250,
 }: {
   imageDetails: string | null;
   setImageDetails: (picture: string | null) => void;
   cameraIsOpenCallback?: (isOpen: boolean) => void;
-  width?: number;
-  height?: number;
+  size?: number;
 }) {
   const [cameraIsOpen, toggleCameraOpen, setCameraIsOpen] = useToggle(true);
 
@@ -58,7 +57,7 @@ export function WebcamInput({
       {!cameraIsOpen && (
         <div
           className="relative flex items-center justify-center bg-gray-400 w-full aspect-square"
-          style={{ maxWidth: width }}
+          style={{ maxWidth: size }}
         >
           {imageDetails != null && (
             <Image src={imageDetails} alt="" fill={true} unoptimized={true} />
@@ -67,7 +66,10 @@ export function WebcamInput({
       )}
 
       {cameraIsOpen && (
-        <div className="flex flex-col items-center justify-center space-y-2 w-full" style={{ maxWidth: width }}>
+        <div
+          className="flex flex-col items-center justify-center space-y-2 w-full"
+          style={{ maxWidth: size }}
+        >
           <Webcam
             audio={false}
             width="100%"

--- a/src/components/interactive/inputs/WebcamInput.tsx
+++ b/src/components/interactive/inputs/WebcamInput.tsx
@@ -23,7 +23,6 @@ export function WebcamInput({
   setImageDetails,
   cameraIsOpenCallback,
   width = 250,
-  height = 250,
 }: {
   imageDetails: string | null;
   setImageDetails: (picture: string | null) => void;
@@ -58,8 +57,8 @@ export function WebcamInput({
       </label>
       {!cameraIsOpen && (
         <div
-          className="relative flex items-center justify-center bg-gray-400"
-          style={{ width, height }}
+          className="relative flex items-center justify-center bg-gray-400 w-full aspect-square"
+          style={{ maxWidth: width }}
         >
           {imageDetails != null && (
             <Image src={imageDetails} alt="" fill={true} unoptimized={true} />
@@ -68,11 +67,10 @@ export function WebcamInput({
       )}
 
       {cameraIsOpen && (
-        <div className="flex flex-col items-center justify-center space-y-2">
+        <div className="flex flex-col items-center justify-center space-y-2 w-full" style={{ maxWidth: width }}>
           <Webcam
             audio={false}
-            width={width}
-            height={height}
+            width="100%"
             ref={webcamRef}
             screenshotFormat="image/jpeg"
             screenshotQuality={1}

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -23,24 +23,26 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
   return (
     <div className="flex h-screen flex-col sm:flex-row">
       {/* mobile sidebar */}
-      <div className="grid sm:hidden grid-cols-3 w-full p-2 items-center bg-[var(--color-navbar)]">
-        <SabaiLogo />
-        <div className="flex justify-center">
-          <VillageSelector />
+      <div className="sm:hidden relative">
+        <div className="grid grid-cols-3 w-full p-2 items-center bg-[var(--color-navbar)]">
+          <SabaiLogo />
+          <div className="flex justify-center">
+            <VillageSelector />
+          </div>
+          <div className="flex justify-end">
+            <button
+              className={`group flex items-center gap-2 p-2 pl-4 rounded-md hover:cursor-pointer`}
+              onClick={() => setMobileSidebarOpen(!mobileSidebarOpen)}
+            >
+              <IoMdMenu className="h-7 w-7 text-white" />
+            </button>
+          </div>
         </div>
-        <div className="flex justify-end">
-          <button
-            className={`group flex items-center gap-2 p-2 pl-4 rounded-md hover:cursor-pointer`}
-            onClick={() => setMobileSidebarOpen(!mobileSidebarOpen)}
-          >
-            <IoMdMenu className="h-7 w-7 text-white" />
-          </button>
+        <div
+          className={`${mobileSidebarOpen ? "flex" : "hidden"} flex-col absolute z-2 w-full p-2 top-full bg-neutral-50 shadow-2xl`}
+        >
+          <SidebarNavButtons />
         </div>
-      </div>
-      <div
-        className={`${mobileSidebarOpen ? "flex" : "hidden"} flex-col absolute z-2 w-full p-2 top-15 bg-neutral-50 shadow-2xl`}
-      >
-        <SidebarNavButtons />
       </div>
       {/* desktop sidebar */}
       <div className="hidden sm:flex flex-col min-w-64 p-2 gap-6 bg-[var(--color-navbar)]">

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -23,10 +23,12 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
   return (
     <div className="flex h-screen flex-col sm:flex-row">
       {/* mobile sidebar */}
-      <div className="flex sm:hidden flex-row w-full p-2 justify-between items-center bg-[var(--color-navbar)]">
+      <div className="grid sm:hidden grid-cols-3 w-full p-2 items-center bg-[var(--color-navbar)]">
         <SabaiLogo />
-        <div className="flex items-center gap-2">
+        <div className="flex justify-center">
           <VillageSelector />
+        </div>
+        <div className="flex justify-end">
           <button
             className={`group flex items-center gap-2 p-2 pl-4 rounded-md hover:cursor-pointer`}
             onClick={() => setMobileSidebarOpen(!mobileSidebarOpen)}

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -12,6 +12,7 @@ import { GiMedicines } from "react-icons/gi";
 import LogoTitle from "@/components/LogoTitle";
 import SabaiLogo from "@/components/SabaiLogo";
 import VillageSelector from "@/components/VillageSelector";
+import { useClickOutside } from "@/hooks/useClickOutside";
 
 interface SidebarLayoutProps {
   children: ReactNode;
@@ -19,11 +20,14 @@ interface SidebarLayoutProps {
 
 export default function SidebarLayout({ children }: SidebarLayoutProps) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const dropdownRef = useClickOutside<HTMLDivElement>(() =>
+    setMobileSidebarOpen(false),
+  );
 
   return (
     <div className="flex h-screen flex-col sm:flex-row">
       {/* mobile sidebar */}
-      <div className="sm:hidden relative">
+      <div className="sm:hidden relative" ref={dropdownRef}>
         <div className="grid grid-cols-3 w-full p-2 items-center bg-[var(--color-navbar)]">
           <SabaiLogo />
           <div className="flex justify-center">

--- a/src/pages/scanFace.tsx
+++ b/src/pages/scanFace.tsx
@@ -123,8 +123,7 @@ function ScanFacePage() {
             imageDetails={imgDetails}
             setImageDetails={setScannedFace}
             cameraIsOpenCallback={cameraToggleCallback}
-            width={500}
-            height={500}
+            size={400}
           />
         </div>
         {/* Create Patient Form */}


### PR DESCRIPTION
Closes #107 

## Description 
1. WebcamInput responsive fix — replaced fixed width/height pixel props with a size prop that acts as a
maxWidth. The webcam feed now uses `width="100%"` and the preview container uses `aspect-square`, so both
shrink to fit narrow mobile viewports instead of overflowing and causing a layout shift when the
camera opens.

2. VillageSelector centering — restructured the mobile navbar to `grid-cols-3`, so the selector sits in the true center column between the logo and menu button.

## Screenshot / Recording to reflect changes

https://github.com/user-attachments/assets/e6095339-7e58-4293-bd4d-6cbe36927352

