### PR TITLE
110 improve vision page layout

### DIFF
--- a/src/__tests__/lib/utils/patient.test.ts
+++ b/src/__tests__/lib/utils/patient.test.ts
@@ -1,0 +1,18 @@
+import { formatPatientCode, formatPatientId } from "@/lib/utils/patient";
+
+describe("formatPatientId", () => {
+  it("zero-pads ids to 4 digits", () => {
+    expect(formatPatientId(12)).toBe("0012");
+  });
+
+  it("leaves ids of 4 or more digits unchanged", () => {
+    expect(formatPatientId(1234)).toBe("1234");
+    expect(formatPatientId(12345)).toBe("12345");
+  });
+});
+
+describe("formatPatientCode", () => {
+  it("prefixes the village code when present", () => {
+    expect(formatPatientCode("PC", 12)).toBe("PC0012");
+  });
+});

--- a/src/components/TableCell.tsx
+++ b/src/components/TableCell.tsx
@@ -22,6 +22,8 @@ export default function TableCell({
   className = "",
 }: TableCellProps) {
   return (
-    <td className={`px-6 py-4 whitespace-nowrap ${className}`}>{children}</td>
+    <td className={`px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap ${className}`}>
+      {children}
+    </td>
   );
 }

--- a/src/components/TableHeader.tsx
+++ b/src/components/TableHeader.tsx
@@ -27,7 +27,7 @@ export default function TableHeader({
         {headers.map((header, index) => (
           <th
             key={index}
-            className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"
+            className="px-3 py-3 sm:px-6 text-left text-xs font-medium text-slate-500 uppercase tracking-wider"
           >
             {header}
           </th>

--- a/src/components/interactive/OldButton/OldButton.tsx
+++ b/src/components/interactive/OldButton/OldButton.tsx
@@ -52,6 +52,7 @@ export function OldButton({
   const [isLoading, setIsLoading] = useState(false);
 
   // Prevent SSR hydration mismatch
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setHydrated(true), []);
 
   const handleClick = async (e: MouseEvent<HTMLButtonElement>) => {

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -25,9 +25,9 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
   );
 
   return (
-    <div className="flex h-screen flex-col sm:flex-row">
+    <div className="flex h-screen flex-col lg:flex-row">
       {/* mobile sidebar */}
-      <div className="sm:hidden relative" ref={dropdownRef}>
+      <div className="lg:hidden relative" ref={dropdownRef}>
         <div className="grid grid-cols-3 w-full p-2 items-center bg-[var(--color-navbar)]">
           <SabaiLogo />
           <div className="flex justify-center">
@@ -49,7 +49,7 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
         </div>
       </div>
       {/* desktop sidebar */}
-      <div className="hidden sm:flex flex-col min-w-64 p-2 gap-6 bg-[var(--color-navbar)]">
+      <div className="hidden lg:flex flex-col min-w-64 p-2 gap-6 bg-[var(--color-navbar)]">
         <LogoTitle className="m-2" />
         <div className="px-2">
           <VillageSelector />

--- a/src/lib/utils/patient.ts
+++ b/src/lib/utils/patient.ts
@@ -1,3 +1,18 @@
+/**
+ * Formats a patient id as a zero-padded, 4-digit string, e.g. 12 → "0012".
+ */
+export function formatPatientId(id: number) {
+  return id.toString().padStart(4, "0");
+}
+
+/**
+ * Builds the display code for a patient, for example "PC0012". Falls back to the
+ * zero-padded id alone when the patient has no village (no visits yet).
+ */
+export function formatPatientCode(villageCode: string | null, id: number) {
+  return `${villageCode ?? ""}${formatPatientId(id)}`;
+}
+
 export function calculateAge(dateOfBirth: Date) {
   const birthDate = new Date(dateOfBirth);
   const now = new Date();

--- a/src/pages/patient/index.tsx
+++ b/src/pages/patient/index.tsx
@@ -8,6 +8,7 @@ import { ReactNode } from "react";
 import TableHeader from "@/components/TableHeader";
 import TableRow from "@/components/TableRow";
 import TableCell from "@/components/TableCell";
+import { formatPatientId } from "@/lib/utils/patient";
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
@@ -78,7 +79,7 @@ function PatientsBasePage() {
                 <TableCell>
                   <div className="flex flex-col items-center gap-2">
                     <span className="text-sm font-medium text-slate-900">
-                      {getPatientIdWithZeroPadding(patient.id, 4) || "No ID"}
+                      {formatPatientId(patient.id) || "No ID"}
                     </span>
                     <PatientPhoto
                       pictureUrl={patient.patientImageUrl}
@@ -170,10 +171,6 @@ function calculateAge(birthDate: Date) {
   const diff = Date.now() - birthDate.getTime();
   const ageDate = new Date(diff);
   return Math.abs(ageDate.getUTCFullYear() - 1970);
-}
-
-function getPatientIdWithZeroPadding(id: number, padLength: number) {
-  return id.toString().padStart(padLength, "0");
 }
 
 PatientsBasePage.getLayout = (page: ReactNode) =>

--- a/src/pages/vision/index.tsx
+++ b/src/pages/vision/index.tsx
@@ -8,29 +8,149 @@ import LoadingSpinner from "@/components/LoadingSpinner";
 import TableHeader from "@/components/TableHeader";
 import TableRow from "@/components/TableRow";
 import TableCell from "@/components/TableCell";
-import { Button } from "@/components/interactive/Button/Button";
 import { ReactNode } from "react";
+import { formatPatientCode } from "@/lib/utils/patient";
+import { PatientsRouterListItem } from "@/utils/trpc-types";
+
+/**
+ * Renders a patient's code with a small dot in the village colour beside it.
+ * The dot is omitted when the patient has no village.
+ */
+function PatientCode({
+  villageCode,
+  villageColorHex,
+  id,
+  className = "",
+}: {
+  villageCode: string | null;
+  villageColorHex: string | null;
+  id: number;
+  className?: string;
+}) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className}`}>
+      {villageColorHex && (
+        <span
+          className="h-3 w-3 rounded-full"
+          style={{ backgroundColor: villageColorHex }}
+          title={villageCode ?? undefined}
+        />
+      )}
+      {formatPatientCode(villageCode, id)}
+    </span>
+  );
+}
+
+function UpdateGlassesButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Update Glasses"
+      className="inline-flex cursor-pointer items-center gap-2 whitespace-nowrap rounded-lg bg-emerald-600 px-3 py-2 text-sm text-white transition hover:bg-emerald-700"
+    >
+      <HiOutlinePencilSquare className="h-5 w-5" />
+      Update Glasses
+    </button>
+  );
+}
+
+/**
+ * Stacked patient card used on small screens, where a 4-column table would
+ * clip or overlap. Photo on the left; code, name and action stacked beside it.
+ */
+function PatientCard({
+  patient,
+  onUpdateGlasses,
+}: {
+  patient: PatientsRouterListItem;
+  onUpdateGlasses: (patientId: number) => void;
+}) {
+  return (
+    <div className="flex gap-10 p-4">
+      <PatientPhoto
+        pictureUrl={patient.patientImageUrl}
+        className="h-14 w-14 rounded-lg border border-slate-200 object-cover"
+      />
+      <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+        <PatientCode
+          villageCode={patient.villageCode}
+          villageColorHex={patient.villageColorHex}
+          id={patient.id}
+          className="text-xs font-medium text-slate-500"
+        />
+        <div className="break-words text-sm font-medium text-slate-900">
+          {patient.name}
+        </div>
+        <UpdateGlassesButton onClick={() => onUpdateGlasses(patient.id)} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full patient table shown on md+ screens, where all four columns fit.
+ */
+function PatientTable({
+  patients,
+  onUpdateGlasses,
+}: {
+  patients: PatientsRouterListItem[];
+  onUpdateGlasses: (patientId: number) => void;
+}) {
+  return (
+    <div className="hidden overflow-x-auto md:block">
+      <table className="min-w-full divide-y divide-slate-200">
+        <TableHeader headers={["ID", "Photo", "Name", "Actions"]} />
+        <tbody className="bg-white divide-y divide-slate-200">
+          {patients.map((patient) => (
+            <TableRow key={patient.id}>
+              <TableCell>
+                <PatientCode
+                  villageCode={patient.villageCode}
+                  villageColorHex={patient.villageColorHex}
+                  id={patient.id}
+                  className="text-sm font-medium text-slate-900"
+                />
+              </TableCell>
+              <TableCell>
+                <PatientPhoto
+                  pictureUrl={patient.patientImageUrl}
+                  className="h-12 w-12 rounded-lg border border-slate-200 object-cover"
+                />
+              </TableCell>
+              <TableCell>
+                <span className="text-sm font-medium text-slate-900">
+                  {patient.name}
+                </span>
+              </TableCell>
+              <TableCell>
+                <UpdateGlassesButton
+                  onClick={() => onUpdateGlasses(patient.id)}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen flex-1 p-8">
-      <div className="w-full mx-auto">
-        <Breadcrumbs
-          items={[{ label: "Home", href: "/" }, { label: "Vision" }]}
-        />
-
-        <div className="flex justify-between items-center mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-slate-900">Vision</h1>
-            <p className="mt-2 text-slate-600">
-              Manage vision prescriptions and eye care records for all patients.
-            </p>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-          {children}
-        </div>
+    <div className="min-h-screen flex-1 p-4 sm:p-6">
+      <Breadcrumbs
+        items={[{ label: "Home", href: "/" }, { label: "Vision" }]}
+      />
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-slate-900">Vision</h1>
+        <p className="mt-2 text-slate-600">
+          Manage vision prescriptions and eye care records for all patients.
+        </p>
+      </div>
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+        {children}
       </div>
     </div>
   );
@@ -70,43 +190,24 @@ function VisionPage() {
     }
 
     return (
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-slate-200">
-          <TableHeader headers={["ID", "Photo", "Full Name", "Actions"]} />
-          <tbody className="bg-white divide-y divide-slate-200">
-            {patients.map((patient) => (
-              <TableRow key={patient.id}>
-                <TableCell>
-                  <div className="text-sm font-medium text-slate-900">
-                    {patient.id.toString().padStart(4, "0")}
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <PatientPhoto
-                    pictureUrl={patient.patientImageUrl}
-                    className="rounded-full border border-slate-200"
-                  />
-                </TableCell>
-                <TableCell>
-                  <div className="text-sm font-medium text-slate-900">
-                    {patient.name}
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <Button
-                    onClick={() => handleUpdateGlasses(patient.id)}
-                    title="Update Glasses"
-                    icon={<HiOutlinePencilSquare className="h-4 w-4" />}
-                    colour="emerald"
-                    variant="filled"
-                    size="medium"
-                  />
-                </TableCell>
-              </TableRow>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <>
+        {/* Small screens: stacked cards (a 4-column table clips at this width) */}
+        <div className="divide-y divide-slate-200 md:hidden">
+          {patients.map((patient) => (
+            <PatientCard
+              key={patient.id}
+              patient={patient}
+              onUpdateGlasses={handleUpdateGlasses}
+            />
+          ))}
+        </div>
+
+        {/* tablet and desktop: full table */}
+        <PatientTable
+          patients={patients}
+          onUpdateGlasses={handleUpdateGlasses}
+        />
+      </>
     );
   }
 

--- a/src/pages/vision/index.tsx
+++ b/src/pages/vision/index.tsx
@@ -56,8 +56,7 @@ function UpdateGlassesButton({ onClick }: { onClick: () => void }) {
 }
 
 /**
- * Stacked patient card used on small screens, where a 4-column table would
- * clip or overlap. Photo on the left; code, name and action stacked beside it.
+ * Stacked patient card used on small screens (e.g mobile)
  */
 function PatientCard({
   patient,
@@ -89,7 +88,7 @@ function PatientCard({
 }
 
 /**
- * Full patient table shown on md+ screens, where all four columns fit.
+ * Full patient table shown on tablet and desktop screens.
  */
 function PatientTable({
   patients,
@@ -191,7 +190,7 @@ function VisionPage() {
 
     return (
       <>
-        {/* Small screens: stacked cards (a 4-column table clips at this width) */}
+        {/* Mobile screens: stacked cards */}
         <div className="divide-y divide-slate-200 md:hidden">
           {patients.map((patient) => (
             <PatientCard
@@ -202,7 +201,7 @@ function VisionPage() {
           ))}
         </div>
 
-        {/* tablet and desktop: full table */}
+        {/* Tablet and desktop screens: full table */}
         <PatientTable
           patients={patients}
           onUpdateGlasses={handleUpdateGlasses}

--- a/src/pages/vision/update-glasses/[patientId].tsx
+++ b/src/pages/vision/update-glasses/[patientId].tsx
@@ -5,6 +5,7 @@ import Breadcrumbs from "@/components/Breadcrumbs";
 import { trpc } from "@/utils/trpc";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
+import { formatPatientId } from "@/lib/utils/patient";
 
 function UpdateGlassesPage() {
   const router = useRouter();
@@ -74,7 +75,7 @@ function UpdateGlassesPage() {
               Update Glasses - {patient.name}
             </h1>
             <p className="mt-2 text-slate-600">
-              Patient ID: {patient.id.toString().padStart(4, "0")}
+              Patient ID: {formatPatientId(patient.id)}
             </p>
           </div>
         </div>

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -3,10 +3,10 @@ import { zfd } from "zod-form-data";
 import { uploadToCloudinary } from "@/server/utils/cloudinary";
 import { router, protectedProcedure } from "@/server/trpc";
 import { db } from "@/db/drizzle";
-import { patients, genderEnum, Patient, visits } from "@/db/schema";
+import { patients, genderEnum, visits, villageCodes } from "@/db/schema";
 import serverEnv from "@/lib/envVariables";
 import { TRPCError } from "@trpc/server";
-import { eq, inArray } from "drizzle-orm";
+import { eq, desc, inArray } from "drizzle-orm";
 import {
   generateFaceprint,
   searchFaceprint,
@@ -22,7 +22,11 @@ const cloudinaryUrlPrefix = serverEnv.CLOUDINARY_URL_PREFIX;
  * @returns A new patient object with the `patientImageUrl` property added. If the patient has a `patientImagePublicId`,
  *          the URL is constructed as `{cloudinaryUrl}/{patientImagePublicId}`. Otherwise, `patientImageUrl` is `null`.
  */
-const getPatientWithImageUrl = (patient: Patient) => ({
+const getPatientWithImageUrl = <
+  T extends { patientImagePublicId: string | null },
+>(
+  patient: T,
+) => ({
   ...patient,
   patientImageUrl: patient.patientImagePublicId
     ? `${cloudinaryUrlPrefix}/${patient.patientImagePublicId}`
@@ -32,6 +36,16 @@ const getPatientWithImageUrl = (patient: Patient) => ({
 export const patientsRouter = router({
   // List all patients with village details
   list: protectedProcedure.query(async () => {
+    // A patient's village is taken from their most recent visit. DISTINCT ON keeps one row per patient, the latest by visit date.
+    const latestVisit = db
+      .selectDistinctOn([visits.patientId], {
+        patientId: visits.patientId,
+        villageCodeId: visits.villageCodeId,
+      })
+      .from(visits)
+      .orderBy(visits.patientId, desc(visits.date))
+      .as("latest_visit");
+
     const result = await db
       .select({
         id: patients.id,
@@ -46,8 +60,12 @@ export const patientsRouter = router({
         hasSabaiCard: patients.hasSabaiCard,
         patientImagePublicId: patients.patientImagePublicId,
         rekognitionFaceId: patients.rekognitionFaceId,
+        villageCode: villageCodes.code,
+        villageColorHex: villageCodes.colorHex,
       })
-      .from(patients);
+      .from(patients)
+      .leftJoin(latestVisit, eq(latestVisit.patientId, patients.id))
+      .leftJoin(villageCodes, eq(villageCodes.id, latestVisit.villageCodeId));
 
     return result.map(getPatientWithImageUrl);
   }),


### PR DESCRIPTION
Closes #110 

## Description

- Improves the Vision page layout and makes the patient list responsive across mobile, tablet, and desktop. 
- Also adds a shared `formatPatientId` / `formatPatientCode` helper 
- Made change to include latest-visit village in the patient list query

## Testing
- Manually verify responsive layouts at mobile / tablet / desktop breakpoints
---

**Mobile View:**

<img width="391" height="848" alt="Screenshot 2026-06-19 at 8 10 59 PM" src="https://github.com/user-attachments/assets/f5c51980-cd5c-4ce5-bc36-0534336fa506" />

---

**Tablet View:**
 
<img width="828" height="1092" alt="Screenshot 2026-06-19 at 8 47 43 PM" src="https://github.com/user-attachments/assets/bf8b1b93-dbf2-4698-af68-59bed10f5302" />

---

**Desktop View:**
 
<img width="1436" height="1124" alt="Screenshot 2026-06-19 at 8 47 53 PM" src="https://github.com/user-attachments/assets/dc76c876-a542-4909-8a96-6a2e0034ab9d" />

---
