### PR TITLE
Vision form

### DIFF
--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -17,10 +17,8 @@ export type EyesightFormValues = {
   leftPrescribedGlassesDegree?: string | null;
   rightPrescribedGlassesDegree?: string | null;
   comments?: string | null;
-  visitSelect: string;
 };
 
-/** Empty form state used as the baseline for a visit with no record yet. */
 const BLANK_EYESIGHT: EyesightFormValues = {
   leftEyeDegree: "",
   rightEyeDegree: "",
@@ -31,12 +29,8 @@ const BLANK_EYESIGHT: EyesightFormValues = {
   leftPrescribedGlassesDegree: "",
   rightPrescribedGlassesDegree: "",
   comments: "",
-  visitSelect: "",
 };
 
-/**
- * Left/right input groups rendered in the prescription form, declared once here.
- */
 const EYE_SECTIONS: {
   title: string;
   fields: { name: keyof EyesightFormValues; label: string }[];
@@ -77,20 +71,17 @@ const EYE_SECTIONS: {
   },
 ];
 
-/**
- * Prescription form for a single visit. Loads any existing eyesight record and
- * upserts (create or insert) on save (create when none exists, otherwise will update by visit).
- */
 export function EyesightForm({ visitId }: { visitId: number }) {
   const {
     reset,
+    getValues,
     handleSubmit,
     formState: { isDirty },
-  } = useFormContext<EyesightFormValues>();
+  } = useFormContext<EyesightFormValues & { visitSelect: string }>();
 
   const { data: eyesightData, isLoading: eyesightLoading } =
     trpc.eyesightRouter.getByVisitId.useQuery(
-      { visitId: visitId },
+      { visitId },
       { enabled: !!visitId },
     );
 
@@ -113,10 +104,11 @@ export function EyesightForm({ visitId }: { visitId: number }) {
 
   useEffect(() => {
     if (eyesightLoading) return;
+    // Preserve visitSelect — it's owned by the parent page, not this form
     reset({
       ...BLANK_EYESIGHT,
       ...eyesightData,
-      visitSelect: visitId.toString(),
+      visitSelect: getValues("visitSelect"),
     });
   }, [eyesightData, eyesightLoading, reset, visitId]);
 
@@ -129,7 +121,7 @@ export function EyesightForm({ visitId }: { visitId: number }) {
     }
 
     const payload = {
-      visitId: visitId,
+      visitId,
       leftEyeDegree: data.leftEyeDegree || undefined,
       rightEyeDegree: data.rightEyeDegree || undefined,
       leftEyePinhole: data.leftEyePinhole || undefined,

--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -83,7 +83,7 @@ export function EyesightForm({
     formState: { isDirty },
     reset: resetCtx,
   } = useFormContext<EyesightFormValues>();
-  
+
   const reset = resetCtx as (
     values: EyesightFormValues & { visitSelect: string },
   ) => void;
@@ -103,7 +103,7 @@ export function EyesightForm({
   useEffect(() => {
     if (eyesightLoading) return;
     reset({ ...BLANK_EYESIGHT, ...eyesightData, visitSelect });
-  }, [eyesightData, eyesightLoading, reset, visitId, visitSelect]);
+  }, [eyesightData, eyesightLoading, reset, visitId, visitSelect]); // visitId not used directly but ensures the form resets on visit change
 
   if (eyesightLoading) return <LoadingSpinner message="Loading vision data" />;
 

--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -1,0 +1,193 @@
+import { useFormContext } from "react-hook-form";
+import { useEffect } from "react";
+import { trpc } from "@/utils/trpc";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import { RHFInput } from "@/components/interactive/RHF/RHFInput";
+import { RHFTextArea } from "@/components/interactive/RHF/RHFTextArea";
+import { Button } from "@/components/interactive/Button/Button";
+import toast from "react-hot-toast";
+
+export type EyesightFormValues = {
+  leftEyeDegree?: string | null;
+  rightEyeDegree?: string | null;
+  leftEyePinhole?: string | null;
+  rightEyePinhole?: string | null;
+  leftAstigmatism?: string | null;
+  rightAstigmatism?: string | null;
+  leftPrescribedGlassesDegree?: string | null;
+  rightPrescribedGlassesDegree?: string | null;
+  comments?: string | null;
+  visitSelect: string;
+};
+
+/** Empty form state used as the baseline for a visit with no record yet. */
+const BLANK_EYESIGHT: EyesightFormValues = {
+  leftEyeDegree: "",
+  rightEyeDegree: "",
+  leftEyePinhole: "",
+  rightEyePinhole: "",
+  leftAstigmatism: "",
+  rightAstigmatism: "",
+  leftPrescribedGlassesDegree: "",
+  rightPrescribedGlassesDegree: "",
+  comments: "",
+  visitSelect: "",
+};
+
+/**
+ * Left/right input groups rendered in the prescription form, declared once here.
+ */
+const EYE_SECTIONS: {
+  title: string;
+  fields: { name: keyof EyesightFormValues; label: string }[];
+}[] = [
+  {
+    title: "Visual Acuity (Degree)",
+    fields: [
+      { name: "leftEyeDegree", label: "Left Eye Degree" },
+      { name: "rightEyeDegree", label: "Right Eye Degree" },
+    ],
+  },
+  {
+    title: "Pinhole",
+    fields: [
+      { name: "leftEyePinhole", label: "Left Eye Pinhole" },
+      { name: "rightEyePinhole", label: "Right Eye Pinhole" },
+    ],
+  },
+  {
+    title: "Astigmatism",
+    fields: [
+      { name: "leftAstigmatism", label: "Left Astigmatism" },
+      { name: "rightAstigmatism", label: "Right Astigmatism" },
+    ],
+  },
+  {
+    title: "Prescribed Glasses (Degree)",
+    fields: [
+      {
+        name: "leftPrescribedGlassesDegree",
+        label: "Left Prescribed Glasses Degree",
+      },
+      {
+        name: "rightPrescribedGlassesDegree",
+        label: "Right Prescribed Glasses Degree",
+      },
+    ],
+  },
+];
+
+/**
+ * Prescription form for a single visit. Loads any existing eyesight record and
+ * upserts (create or insert) on save (create when none exists, otherwise will update by visit).
+ */
+export function EyesightForm({ visitId }: { visitId: number }) {
+  const {
+    reset,
+    handleSubmit,
+    formState: { isDirty },
+  } = useFormContext<EyesightFormValues>();
+
+  const { data: eyesightData, isLoading: eyesightLoading } =
+    trpc.eyesightRouter.getByVisitId.useQuery(
+      { visitId: visitId },
+      { enabled: !!visitId },
+    );
+
+  const utils = trpc.useUtils();
+
+  const mutationOptions = {
+    onSuccess: () => {
+      utils.eyesightRouter.getByVisitId.invalidate({ visitId });
+      toast.success("Vision record saved successfully!");
+    },
+    onError: () => {
+      toast.error("Failed to save vision record.");
+    },
+  };
+
+  const createEyesightMutation =
+    trpc.eyesightRouter.create.useMutation(mutationOptions);
+  const updateEyesightMutation =
+    trpc.eyesightRouter.updateByVisitId.useMutation(mutationOptions);
+
+  useEffect(() => {
+    if (eyesightLoading) return;
+    reset({
+      ...BLANK_EYESIGHT,
+      ...eyesightData,
+      visitSelect: visitId.toString(),
+    });
+  }, [eyesightData, eyesightLoading, reset, visitId]);
+
+  if (eyesightLoading) return <LoadingSpinner message="Loading vision data" />;
+
+  const onSubmit = (data: EyesightFormValues) => {
+    if (!isDirty) {
+      toast.error("No form field changed!");
+      return;
+    }
+
+    const payload = {
+      visitId: visitId,
+      leftEyeDegree: data.leftEyeDegree || undefined,
+      rightEyeDegree: data.rightEyeDegree || undefined,
+      leftEyePinhole: data.leftEyePinhole || undefined,
+      rightEyePinhole: data.rightEyePinhole || undefined,
+      leftAstigmatism: data.leftAstigmatism || undefined,
+      rightAstigmatism: data.rightAstigmatism || undefined,
+      leftPrescribedGlassesDegree:
+        data.leftPrescribedGlassesDegree || undefined,
+      rightPrescribedGlassesDegree:
+        data.rightPrescribedGlassesDegree || undefined,
+      comments: data.comments || undefined,
+    };
+
+    if (!eyesightData) {
+      createEyesightMutation.mutate(payload);
+    } else {
+      updateEyesightMutation.mutate(payload);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+      {EYE_SECTIONS.map((section) => (
+        <section key={section.title} className="space-y-4">
+          <h2 className="text-sm font-semibold text-slate-700">
+            {section.title}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {section.fields.map((field) => (
+              <RHFInput
+                key={field.name}
+                name={field.name}
+                label={field.label}
+                type="text"
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <section className="space-y-4">
+        <RHFTextArea name="comments" label="Comments" rows={3} />
+      </section>
+
+      <div className="flex justify-end pt-4 border-t border-slate-100">
+        <div className="w-full md:w-44">
+          <Button
+            type="submit"
+            title="Save Records"
+            colour="emerald"
+            variant="filled"
+            loading={
+              createEyesightMutation.isPending ||
+              updateEyesightMutation.isPending
+            }
+          />
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -71,13 +71,22 @@ const EYE_SECTIONS: {
   },
 ];
 
-export function EyesightForm({ visitId }: { visitId: number }) {
+export function EyesightForm({
+  visitId,
+  visitSelect,
+}: {
+  visitId: number;
+  visitSelect: string;
+}) {
+  const ctx = useFormContext<EyesightFormValues>();
   const {
-    reset,
-    getValues,
     handleSubmit,
     formState: { isDirty },
-  } = useFormContext<EyesightFormValues & { visitSelect: string }>();
+  } = ctx;
+
+  const reset = ctx.reset as (
+    values: EyesightFormValues & { visitSelect: string },
+  ) => void;
 
   const { data: eyesightData, isLoading: eyesightLoading } =
     trpc.eyesightRouter.getByVisitId.useQuery(
@@ -87,30 +96,14 @@ export function EyesightForm({ visitId }: { visitId: number }) {
 
   const utils = trpc.useUtils();
 
-  const mutationOptions = {
-    onSuccess: () => {
-      utils.eyesightRouter.getByVisitId.invalidate({ visitId });
-      toast.success("Vision record saved successfully!");
-    },
-    onError: () => {
-      toast.error("Failed to save vision record.");
-    },
-  };
-
-  const createEyesightMutation =
-    trpc.eyesightRouter.create.useMutation(mutationOptions);
+  const createEyesightMutation = trpc.eyesightRouter.create.useMutation();
   const updateEyesightMutation =
-    trpc.eyesightRouter.updateByVisitId.useMutation(mutationOptions);
+    trpc.eyesightRouter.updateByVisitId.useMutation();
 
   useEffect(() => {
     if (eyesightLoading) return;
-    // Preserve visitSelect — it's owned by the parent page, not this form
-    reset({
-      ...BLANK_EYESIGHT,
-      ...eyesightData,
-      visitSelect: getValues("visitSelect"),
-    });
-  }, [eyesightData, eyesightLoading, reset, visitId]);
+    reset({ ...BLANK_EYESIGHT, ...eyesightData, visitSelect });
+  }, [eyesightData, eyesightLoading, reset, visitId, visitSelect]);
 
   if (eyesightLoading) return <LoadingSpinner message="Loading vision data" />;
 
@@ -135,10 +128,18 @@ export function EyesightForm({ visitId }: { visitId: number }) {
       comments: data.comments || undefined,
     };
 
+    const onSuccess = () => {
+      utils.eyesightRouter.getByVisitId.invalidate({ visitId });
+      toast.success("Vision record saved successfully!");
+      // Re-baseline immediately so isDirty reflects changes since this save
+      reset({ ...data, visitSelect });
+    };
+    const onError = () => toast.error("Failed to save vision record.");
+
     if (!eyesightData) {
-      createEyesightMutation.mutate(payload);
+      createEyesightMutation.mutate(payload, { onSuccess, onError });
     } else {
-      updateEyesightMutation.mutate(payload);
+      updateEyesightMutation.mutate(payload, { onSuccess, onError });
     }
   };
 

--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -78,13 +78,13 @@ export function EyesightForm({
   visitId: number;
   visitSelect: string;
 }) {
-  const ctx = useFormContext<EyesightFormValues>();
   const {
     handleSubmit,
     formState: { isDirty },
-  } = ctx;
-
-  const reset = ctx.reset as (
+    reset: resetCtx,
+  } = useFormContext<EyesightFormValues>();
+  
+  const reset = resetCtx as (
     values: EyesightFormValues & { visitSelect: string },
   ) => void;
 

--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -103,7 +103,7 @@ export function EyesightForm({
   useEffect(() => {
     if (eyesightLoading) return;
     reset({ ...BLANK_EYESIGHT, ...eyesightData, visitSelect });
-  }, [eyesightData, eyesightLoading, reset, visitId, visitSelect]); // visitId not used directly but ensures the form resets on visit change
+  }, [eyesightData, eyesightLoading, reset, visitId, visitSelect]); // eyesightData and visitSelect are redundant alongside visitId (both change when visitId changes), but included to satisfy the linter
 
   if (eyesightLoading) return <LoadingSpinner message="Loading vision data" />;
 

--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -131,7 +131,7 @@ export function EyesightForm({
     const onSuccess = () => {
       utils.eyesightRouter.getByVisitId.invalidate({ visitId });
       toast.success("Vision record saved successfully!");
-      // Re-baseline immediately so isDirty reflects changes since this save
+
       reset({ ...data, visitSelect });
     };
     const onError = () => toast.error("Failed to save vision record.");

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -234,6 +234,8 @@ Eyesight Table:
 - left_astigmatism: Left eye astigmatism measurement.
 - right_astigmatism: Right eye astigmatism measurement.
 - comments: Additional comments or observations.
+- left_prescribed_glasses_degree: Prescribed glasses degree for the left eye.
+- right_prescribed_glasses_degree: Prescribed glasses degree for the right eye.
 */
 export const eyesight = pgTable("eyesight", {
   id: serial("id").primaryKey(),
@@ -250,6 +252,8 @@ export const eyesight = pgTable("eyesight", {
   leftAstigmatism: text("left_astigmatism"),
   rightAstigmatism: text("right_astigmatism"),
   comments: text("comments"),
+  leftPrescribedGlassesDegree: text("left_prescribed_glasses_degree"),
+  rightPrescribedGlassesDegree: text("right_prescribed_glasses_degree"),
 });
 
 export type Eyesight = typeof eyesight.$inferSelect;

--- a/src/lib/utils/visit.ts
+++ b/src/lib/utils/visit.ts
@@ -1,0 +1,16 @@
+/**
+ * Formats a visit date into a readable string in GB locale,
+ * e.g. "22 June 2026, 14:30".
+ *
+ * @param {Date} date - The date to format.
+ * @returns {string} Formatted date string in GB locale.
+ */
+export function formatVisitDate(date: Date): string {
+  return new Date(date).toLocaleString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/src/pages/vision/update-glasses/[patientId].tsx
+++ b/src/pages/vision/update-glasses/[patientId].tsx
@@ -66,7 +66,7 @@ function UpdateGlassesPage() {
           items={[
             { label: "Home", href: "/" },
             { label: "Vision", href: "/vision" },
-            { label: `Update Glasses - ${patient.name}` },
+            { label: `Update Glasses — ${patient.name}` },
           ]}
         />
 

--- a/src/pages/vision/update-glasses/[patientId].tsx
+++ b/src/pages/vision/update-glasses/[patientId].tsx
@@ -115,7 +115,10 @@ function UpdateGlassesPage() {
 
             <div className="p-6">
               {selectedVisit ? (
-                <EyesightForm visitId={selectedVisit.id} />
+                <EyesightForm
+                  visitId={selectedVisit.id}
+                  visitSelect={selectedVisitValue ?? ""}
+                />
               ) : (
                 visits &&
                 visits.length > 0 && (

--- a/src/pages/vision/update-glasses/[patientId].tsx
+++ b/src/pages/vision/update-glasses/[patientId].tsx
@@ -1,16 +1,21 @@
 import { useRouter } from "next/router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
+import { useEffect } from "react";
 import withDefaultLayout from "@/components/layouts/withDefaultLayout";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { trpc } from "@/utils/trpc";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
+import { EyesightForm, EyesightFormValues } from "@/components/vision/EyesightForm";
+import { formatVisitDate } from "@/lib/utils/visit";
 import { formatPatientId } from "@/lib/utils/patient";
+
+type UpdateGlassesFormValues = EyesightFormValues & { visitSelect: string };
 
 function UpdateGlassesPage() {
   const router = useRouter();
   const { patientId } = router.query;
-  const methods = useForm();
+  const methods = useForm<UpdateGlassesFormValues>();
 
   const { data: patient, isLoading: patientLoading } =
     trpc.patientsRouter.getById.useQuery(
@@ -30,12 +35,23 @@ function UpdateGlassesPage() {
     name: "visitSelect",
   });
 
-  if (patientLoading || visitsLoading) {
+  // Automatically select visit if only got one
+  useEffect(() => {
+    if (visits && visits.length === 1) {
+      methods.setValue("visitSelect", visits[0].id.toString());
+    }
+  }, [visits, methods]);
+
+  if (!router.isReady || patientLoading || visitsLoading) {
     return <LoadingSpinner message="Loading patient and visits..." />;
   }
 
   if (!patient) {
-    return <div>Patient not found</div>;
+    return (
+      <div className="p-8 text-center font-semibold text-red-500">
+        Patient not found
+      </div>
+    );
   }
 
   // Only get selected visit when explicitly chosen from dropdown
@@ -43,24 +59,9 @@ function UpdateGlassesPage() {
     ? visits?.find((v) => v.id.toString() === selectedVisitValue)
     : null;
 
-  /**
-   * Formats a visit date into a readable string format.
-   * @param {Date} date - The date to format
-   * @returns {string} Formatted date string in GB locale
-   */
-  const formatVisitDate = (date: Date) => {
-    return new Date(date).toLocaleString("en-GB", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  };
-
   return (
-    <div className="min-h-screen flex-1 p-8">
-      <div className="w-full mx-auto">
+    <div className="min-h-screen flex-1 p-8 bg-slate-50">
+      <div className="w-full mx-auto max-w-5xl">
         <Breadcrumbs
           items={[
             { label: "Home", href: "/" },
@@ -72,7 +73,7 @@ function UpdateGlassesPage() {
         <div className="flex justify-between items-center mb-8">
           <div>
             <h1 className="text-3xl font-bold text-slate-900">
-              Update Glasses - {patient.name}
+              Update Glasses — {patient.name}
             </h1>
             <p className="mt-2 text-slate-600">
               Patient ID: {formatPatientId(patient.id)}
@@ -80,49 +81,52 @@ function UpdateGlassesPage() {
           </div>
         </div>
 
-        <FormProvider {...methods}>
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
-            {visits && visits.length > 0 ? (
-              <div className="mb-6">
-                {selectedVisit ? (
-                  <>
-                    <div className="text-sm text-slate-600 mb-2">
-                      Currently viewing vision data for visit on
-                    </div>
-                    <div className="text-lg font-semibold text-slate-900 mb-2">
-                      {formatVisitDate(selectedVisit.date)}
-                    </div>
-                  </>
-                ) : (
-                  <div className="text-lg font-semibold text-slate-900 mb-2">
-                    No visit selected
+        <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+          <FormProvider {...methods}>
+            <div className="p-6 border-b border-slate-100 bg-slate-50/50">
+              {visits && visits.length > 0 ? (
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:items-center">
+                  <div className="w-full max-w-md">
+                    <RHFDropdown
+                      name="visitSelect"
+                      label="Choose visit"
+                      dropdownOptions={visits.map((visit) => ({
+                        label: formatVisitDate(visit.date),
+                        value: visit.id.toString(),
+                      }))}
+                    />
                   </div>
-                )}
-                <div className="mb-4">
-                  <RHFDropdown
-                    name="visitSelect"
-                    label="Select a different visit to compare historical vision data"
-                    dropdownOptions={visits.map((visit) => ({
-                      label: formatVisitDate(visit.date),
-                      value: visit.id.toString(),
-                    }))}
-                  />
+                  <div className="text-center text-sm text-slate-600">
+                    Filling up vision form for visit on{" "}
+                    <span className="font-semibold text-slate-900">
+                      {selectedVisit
+                        ? formatVisitDate(selectedVisit.date)
+                        : "-"}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            ) : (
-              <div className="p-4 mb-4 bg-amber-50 border border-amber-200 rounded-md">
-                <p className="text-amber-700">
+              ) : (
+                <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg text-amber-700">
                   No visits found for this patient. Please create a visit first
                   to update glasses prescription.
-                </p>
-              </div>
-            )}
-
-            <div className="text-slate-500">
-              Vision prescription form will be implemented here...
+                </div>
+              )}
             </div>
-          </div>
-        </FormProvider>
+
+            <div className="p-6">
+              {selectedVisit ? (
+                <EyesightForm visitId={selectedVisit.id} />
+              ) : (
+                visits &&
+                visits.length > 0 && (
+                  <div className="text-center py-12 text-slate-400 font-medium border-2 border-dashed border-slate-200 rounded-xl">
+                    Please choose a visit to view vision data.
+                  </div>
+                )
+              )}
+            </div>
+          </FormProvider>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/vision/update-glasses/[patientId].tsx
+++ b/src/pages/vision/update-glasses/[patientId].tsx
@@ -6,7 +6,10 @@ import Breadcrumbs from "@/components/Breadcrumbs";
 import { trpc } from "@/utils/trpc";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
-import { EyesightForm, EyesightFormValues } from "@/components/vision/EyesightForm";
+import {
+  EyesightForm,
+  EyesightFormValues,
+} from "@/components/vision/EyesightForm";
 import { formatVisitDate } from "@/lib/utils/visit";
 import { formatPatientId } from "@/lib/utils/patient";
 
@@ -16,6 +19,7 @@ function UpdateGlassesPage() {
   const router = useRouter();
   const { patientId } = router.query;
   const methods = useForm<UpdateGlassesFormValues>();
+  const { setValue } = methods;
 
   const { data: patient, isLoading: patientLoading } =
     trpc.patientsRouter.getById.useQuery(
@@ -38,9 +42,9 @@ function UpdateGlassesPage() {
   // Automatically select visit if only got one
   useEffect(() => {
     if (visits && visits.length === 1) {
-      methods.setValue("visitSelect", visits[0].id.toString());
+      setValue("visitSelect", visits[0].id.toString());
     }
-  }, [visits, methods]);
+  }, [visits, setValue]);
 
   if (!router.isReady || patientLoading || visitsLoading) {
     return <LoadingSpinner message="Loading patient and visits..." />;

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -91,7 +91,7 @@ export default function PatientVitalsPage() {
           items={[
             { label: "Home", href: "/" },
             { label: "Vitals", href: "/vitals" },
-            { label: `Vitals for - ${patient.name}` },
+            { label: `Vitals for — ${patient.name}` },
           ]}
         />
 

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -40,6 +40,7 @@ export default function PatientVitalsPage() {
   const router = useRouter();
   const { id } = router.query;
   const methods = useForm();
+  const { setValue } = methods;
 
   // Fetch patient
   const { data: patient, isLoading: patientLoading } =
@@ -61,9 +62,9 @@ export default function PatientVitalsPage() {
   // Automatically select visit if only got one
   useEffect(() => {
     if (visits && visits.length == 1) {
-      methods.setValue("visitSelect", visits[0].id.toString());
+      setValue("visitSelect", visits[0].id.toString());
     }
-  }, [visits, methods]);
+  }, [visits, setValue]);
 
   // Ensure the router is fully initialized and patientId exists
   if (!router.isReady || patientLoading || visitsLoading) {

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -17,6 +17,7 @@ import { RHFRadio } from "@/components/interactive/RHF/RHFRadio";
 import { RHFTextArea } from "@/components/interactive/RHF/RHFTextArea";
 import { Button } from "@/components/interactive/Button/Button";
 import toast from "react-hot-toast";
+import { formatVisitDate } from "@/lib/utils/visit";
 
 type VitalsFormValues = {
   height?: string | null;
@@ -82,16 +83,6 @@ export default function PatientVitalsPage() {
   const selectedVisit = selectedVisitValue
     ? visits?.find((v) => v.id.toString() === selectedVisitValue)
     : null;
-
-  const formatVisitDate = (date: Date) => {
-    return new Date(date).toLocaleString("en-GB", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  };
 
   return (
     <div className="min-h-screen flex-1 p-8 bg-slate-50">

--- a/src/server/routers/eyesight_router.ts
+++ b/src/server/routers/eyesight_router.ts
@@ -18,6 +18,8 @@ const selectEyesightFields = {
   leftAstigmatism: eyesight.leftAstigmatism,
   rightAstigmatism: eyesight.rightAstigmatism,
   comments: eyesight.comments,
+  leftPrescribedGlassesDegree: eyesight.leftPrescribedGlassesDegree,
+  rightPrescribedGlassesDegree: eyesight.rightPrescribedGlassesDegree,
 };
 
 /**
@@ -32,6 +34,8 @@ const createEyesightInput = z.object({
   leftAstigmatism: z.string().optional(),
   rightAstigmatism: z.string().optional(),
   comments: z.string().optional(),
+  leftPrescribedGlassesDegree: z.string().optional(),
+  rightPrescribedGlassesDegree: z.string().optional(),
 });
 
 /**

--- a/supabase/migrations/0009_yummy_nekra.sql
+++ b/supabase/migrations/0009_yummy_nekra.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "eyesight" ADD COLUMN "left_prescribed_glasses_degree" text;--> statement-breakpoint
+ALTER TABLE "eyesight" ADD COLUMN "right_prescribed_glasses_degree" text;

--- a/supabase/migrations/meta/0009_snapshot.json
+++ b/supabase/migrations/meta/0009_snapshot.json
@@ -1,0 +1,629 @@
+{
+  "id": "f447a840-00b2-4f76-8541-ff81dbe8e645",
+  "prevId": "6e4913f1-409f-4ab0-8559-abb61e133764",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.eyesight": {
+      "name": "eyesight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "left_eye_degree": {
+          "name": "left_eye_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_eye_degree": {
+          "name": "right_eye_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_eye_pinhole": {
+          "name": "left_eye_pinhole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_eye_pinhole": {
+          "name": "right_eye_pinhole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_astigmatism": {
+          "name": "left_astigmatism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_astigmatism": {
+          "name": "right_astigmatism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_prescribed_glasses_degree": {
+          "name": "left_prescribed_glasses_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_prescribed_glasses_degree": {
+          "name": "right_prescribed_glasses_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "eyesight_visit_id_visits_id_fk": {
+          "name": "eyesight_visit_id_visits_id_fk",
+          "tableFrom": "eyesight",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "eyesight_visit_id_unique": {
+          "name": "eyesight_visit_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_active_ingredients": {
+      "name": "medication_active_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measurement": {
+          "name": "unit_of_measurement",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fall_below": {
+          "name": "fall_below",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_brands": {
+      "name": "medication_brands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_ingredient_id": {
+          "name": "active_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_brands_active_ingredient_id_medication_active_ingredients_id_fk": {
+          "name": "medication_brands_active_ingredient_id_medication_active_ingredients_id_fk",
+          "tableFrom": "medication_brands",
+          "tableTo": "medication_active_ingredients",
+          "columnsFrom": [
+            "active_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_stock": {
+      "name": "medication_stock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_brand_id": {
+          "name": "medication_brand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_status": {
+          "name": "stock_status",
+          "type": "medication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_stock_medication_brand_id_medication_brands_id_fk": {
+          "name": "medication_stock_medication_brand_id_medication_brands_id_fk",
+          "tableFrom": "medication_stock",
+          "tableTo": "medication_brands",
+          "columnsFrom": [
+            "medication_brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_no": {
+          "name": "contact_no",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_allergy": {
+          "name": "drug_allergy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_poor_card": {
+          "name": "has_poor_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_bs2_card": {
+          "name": "has_bs2_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_sabai_card": {
+          "name": "has_sabai_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_image_public_id": {
+          "name": "patient_image_public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rekognition_face_id": {
+          "name": "rekognition_face_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.village_codes": {
+      "name": "village_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "village_codes_code_unique": {
+          "name": "village_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visits": {
+      "name": "visits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "village_code_id": {
+          "name": "village_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "visits_patient_id_patients_id_fk": {
+          "name": "visits_patient_id_patients_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visits_village_code_id_village_codes_id_fk": {
+          "name": "visits_village_code_id_village_codes_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "village_codes",
+          "columnsFrom": [
+            "village_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vitals": {
+      "name": "vitals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hemocue_count": {
+          "name": "hemocue_count",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diabetes_mellitus": {
+          "name": "diabetes_mellitus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urine_test": {
+          "name": "urine_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_glucose_non_fasting": {
+          "name": "blood_glucose_non_fasting",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_glucose_fasting": {
+          "name": "blood_glucose_fasting",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hba1c": {
+          "name": "hba1c",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "others": {
+          "name": "others",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vitals_visit_id_visits_id_fk": {
+          "name": "vitals_visit_id_visits_id_fk",
+          "tableFrom": "vitals",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vitals_visit_id_unique": {
+          "name": "vitals_visit_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.medication_status": {
+      "name": "medication_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disposed",
+        "donated",
+        "expired"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781540125999,
       "tag": "0008_sweet_elektra",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1782138313274,
+      "tag": "0009_yummy_nekra",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Description

- Implements the eyesight prescription form on the update glasses page.
- Tests to be made in separate PR, LOC reaching almost 1k

## Changes made
- `formatVisitDate` util: Extracted from vitals page into `src/lib/utils/visit.ts` and reused across both pages.
- new `EyesightForm` component added.
- Update glasses page: Replaced the placeholder with the live EyesightForm and typed the shared form.
- DB: Added `left_prescribed_glasses_degree` and `right_prescribed_glasses_degree` columns to the eyesight table with a migration
- Router: Wired up the two new fields into selectEyesightFields and createEyesightInput in `eyesight_router.ts`

## Screenshot of UI

<img width="429" height="880" alt="Screenshot 2026-06-26 at 8 44 38 AM" src="https://github.com/user-attachments/assets/b8c329e6-5a52-425f-b2aa-ddb3da06763e" />
