### PR TITLE
117 refactor patient list procedure

### DIFF
--- a/src/components/PatientCode.tsx
+++ b/src/components/PatientCode.tsx
@@ -1,0 +1,26 @@
+import { formatPatientCode } from "@/lib/utils/patient";
+
+export function PatientCode({
+  villageCode,
+  villageColorHex,
+  id,
+  className = "",
+}: {
+  villageCode: string | null;
+  villageColorHex: string | null;
+  id: number;
+  className?: string;
+}) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className}`}>
+      {villageColorHex && (
+        <span
+          className="h-3 w-3 rounded-full"
+          style={{ backgroundColor: villageColorHex }}
+          title={villageCode ?? undefined}
+        />
+      )}
+      {formatPatientCode(villageCode, id)}
+    </span>
+  );
+}

--- a/src/pages/vision/index.tsx
+++ b/src/pages/vision/index.tsx
@@ -10,7 +10,7 @@ import TableRow from "@/components/TableRow";
 import TableCell from "@/components/TableCell";
 import { ReactNode } from "react";
 import { formatPatientCode } from "@/lib/utils/patient";
-import { PatientsRouterListItem } from "@/utils/trpc-types";
+import { PatientsRouterListWithLatestVisitItem } from "@/utils/trpc-types";
 
 /**
  * Renders a patient's code with a small dot in the village colour beside it.
@@ -62,7 +62,7 @@ function PatientCard({
   patient,
   onUpdateGlasses,
 }: {
-  patient: PatientsRouterListItem;
+  patient: PatientsRouterListWithLatestVisitItem;
   onUpdateGlasses: (patientId: number) => void;
 }) {
   return (
@@ -94,7 +94,7 @@ function PatientTable({
   patients,
   onUpdateGlasses,
 }: {
-  patients: PatientsRouterListItem[];
+  patients: PatientsRouterListWithLatestVisitItem[];
   onUpdateGlasses: (patientId: number) => void;
 }) {
   return (
@@ -161,7 +161,7 @@ function VisionPage() {
     data: patients,
     isLoading,
     isError,
-  } = trpc.patientsRouter.list.useQuery();
+  } = trpc.patientsRouter.listWithLatestVisit.useQuery();
 
   /**
    * Navigates to the update glasses page for a specific patient.

--- a/src/pages/vision/index.tsx
+++ b/src/pages/vision/index.tsx
@@ -9,37 +9,8 @@ import TableHeader from "@/components/TableHeader";
 import TableRow from "@/components/TableRow";
 import TableCell from "@/components/TableCell";
 import { ReactNode } from "react";
-import { formatPatientCode } from "@/lib/utils/patient";
 import { PatientsRouterListWithLatestVisitItem } from "@/utils/trpc-types";
-
-/**
- * Renders a patient's code with a small dot in the village colour beside it.
- * The dot is omitted when the patient has no village.
- */
-function PatientCode({
-  villageCode,
-  villageColorHex,
-  id,
-  className = "",
-}: {
-  villageCode: string | null;
-  villageColorHex: string | null;
-  id: number;
-  className?: string;
-}) {
-  return (
-    <span className={`inline-flex items-center gap-2 ${className}`}>
-      {villageColorHex && (
-        <span
-          className="h-3 w-3 rounded-full"
-          style={{ backgroundColor: villageColorHex }}
-          title={villageCode ?? undefined}
-        />
-      )}
-      {formatPatientCode(villageCode, id)}
-    </span>
-  );
-}
+import { PatientCode } from "@/components/PatientCode";
 
 function UpdateGlassesButton({ onClick }: { onClick: () => void }) {
   return (

--- a/src/pages/vitals/index.tsx
+++ b/src/pages/vitals/index.tsx
@@ -10,6 +10,7 @@ import TableCell from "@/components/TableCell";
 import { useRouter } from "next/router";
 import { Button } from "@/components/interactive/Button/Button";
 import { CiMedicalClipboard } from "react-icons/ci";
+import { PatientCode } from "@/components/PatientCode";
 
 export default function VitalsPage() {
   const router = useRouter();
@@ -27,7 +28,7 @@ export default function VitalsPage() {
     data: patients,
     isLoading,
     isError,
-  } = trpc.patientsRouter.list.useQuery();
+  } = trpc.patientsRouter.listWithLatestVisit.useQuery();
 
   function renderContent() {
     if (isError) {
@@ -55,7 +56,11 @@ export default function VitalsPage() {
               <TableRow key={patient.id}>
                 <TableCell>
                   <span className="text-sm font-medium text-slate-900">
-                    {patient.id || "No id found"}
+                    <PatientCode
+                      villageCode={patient.villageCode}
+                      villageColorHex={patient.villageColorHex}
+                      id={patient.id}
+                    />
                   </span>
                 </TableCell>
                 <TableCell>

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -63,6 +63,7 @@ export const patientsRouter = router({
       .selectDistinctOn([visits.patientId], {
         patientId: visits.patientId,
         villageCodeId: visits.villageCodeId,
+        date: visits.date,
       })
       .from(visits)
       .orderBy(visits.patientId, desc(visits.date))
@@ -87,7 +88,9 @@ export const patientsRouter = router({
       })
       .from(patients)
       .leftJoin(latestVisit, eq(latestVisit.patientId, patients.id))
-      .leftJoin(villageCodes, eq(villageCodes.id, latestVisit.villageCodeId));
+      .leftJoin(villageCodes, eq(villageCodes.id, latestVisit.villageCodeId))
+      // Most recent visit on top
+      .orderBy(desc(latestVisit.date));
 
     return result.map(getPatientWithImageUrl);
   }),

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -34,9 +34,31 @@ const getPatientWithImageUrl = <
 });
 
 export const patientsRouter = router({
-  // List all patients with village details
+  // List all of patients (no visit data)
   list: protectedProcedure.query(async () => {
-    // A patient's village is taken from their most recent visit. DISTINCT ON keeps one row per patient, the latest by visit date.
+    const result = await db
+      .select({
+        id: patients.id,
+        name: patients.name,
+        identificationNumber: patients.identificationNumber,
+        contactNo: patients.contactNo,
+        gender: patients.gender,
+        dateOfBirth: patients.dateOfBirth,
+        hasPoorCard: patients.hasPoorCard,
+        hasBS2Card: patients.hasBS2Card,
+        drugAllergy: patients.drugAllergy,
+        hasSabaiCard: patients.hasSabaiCard,
+        patientImagePublicId: patients.patientImagePublicId,
+        rekognitionFaceId: patients.rekognitionFaceId,
+      })
+      .from(patients);
+
+    return result.map(getPatientWithImageUrl);
+  }),
+
+  // List all patients, along with village info from their most recent visit
+  listWithLatestVisit: protectedProcedure.query(async () => {
+    // DISTINCT ON keeps one row per patient, the latest by visit date
     const latestVisit = db
       .selectDistinctOn([visits.patientId], {
         patientId: visits.patientId,

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -6,7 +6,7 @@ import { db } from "@/db/drizzle";
 import { patients, genderEnum, visits, villageCodes } from "@/db/schema";
 import serverEnv from "@/lib/envVariables";
 import { TRPCError } from "@trpc/server";
-import { eq, desc, inArray } from "drizzle-orm";
+import { eq, desc, inArray, isNotNull } from "drizzle-orm";
 import {
   generateFaceprint,
   searchFaceprint,
@@ -89,8 +89,9 @@ export const patientsRouter = router({
       .from(patients)
       .leftJoin(latestVisit, eq(latestVisit.patientId, patients.id))
       .leftJoin(villageCodes, eq(villageCodes.id, latestVisit.villageCodeId))
-      // Most recent visit on top
-      .orderBy(desc(latestVisit.date));
+      // Patients with a visit first (isNotNull true sorts before false), then
+      // most recent visit on top; visit-less patients sink to the bottom.
+      .orderBy(desc(isNotNull(latestVisit.date)), desc(latestVisit.date));
 
     return result.map(getPatientWithImageUrl);
   }),

--- a/src/utils/trpc-types.ts
+++ b/src/utils/trpc-types.ts
@@ -2,3 +2,8 @@ import type { RouterOutput } from "@/utils/trpc";
 
 export type PatientsRouterListOutput = RouterOutput["patientsRouter"]["list"];
 export type PatientsRouterListItem = PatientsRouterListOutput[number];
+
+export type PatientsRouterListWithLatestVisitOutput =
+  RouterOutput["patientsRouter"]["listWithLatestVisit"];
+export type PatientsRouterListWithLatestVisitItem =
+  PatientsRouterListWithLatestVisitOutput[number];


### PR DESCRIPTION
Closes #117

## Description:

- `patientsRouter.list` now returns plain patient rows with no JOINS — temporarily used by patients page 
- New `patientsRouter.listWithLatestVisit` carries the existing visits/villageCodes JOIN — used by the vision page which for now needs villageCode and villageColorHex, whether this will be used in the other pages will be in future works
- Updated `trpc-types` to export types for both procedures
- Vision page updated to use `listWithLatestVisit` and its corresponding type
- Delete `src/__tests__/pages/vitals/[id]/index.test.tsx` file, tests for vitals will be covered in separate PR as this PR is focused on refactoring