### PR TITLE
#109: Refactor Rekognition client instantiation

### DIFF
--- a/src/__tests__/pages/scan-face.test.tsx
+++ b/src/__tests__/pages/scan-face.test.tsx
@@ -9,7 +9,6 @@ import { Toaster, toast } from "react-hot-toast";
 import ScanFacePage from "@/pages/scan-face";
 import Webcam from "react-webcam";
 import { VillageCodeProvider } from "@/lib/context/VillageCodeContext";
-import { useState } from "react";
 
 // Mock tRPC
 vi.mock("@/utils/trpc", () => ({

--- a/src/components/scanFace/MatchingPatients.tsx
+++ b/src/components/scanFace/MatchingPatients.tsx
@@ -51,7 +51,7 @@ export default function MatchingPatients({
 
   useEffect(() => {
     findFaceMatchMutation.mutate({ picture: imgDetails! });
-  }, []);
+  }, [findFaceMatchMutation, imgDetails]);
 
   if (findFaceMatchMutation.isPending) {
     return (

--- a/src/components/scanFace/MatchingPatients.tsx
+++ b/src/components/scanFace/MatchingPatients.tsx
@@ -51,7 +51,8 @@ export default function MatchingPatients({
 
   useEffect(() => {
     findFaceMatchMutation.mutate({ picture: imgDetails! });
-  }, [findFaceMatchMutation, imgDetails]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [imgDetails]); // suppress warning about missing dependencies because we only want to run this effect when imgDetails changes
 
   if (findFaceMatchMutation.isPending) {
     return (

--- a/src/lib/utils/facialRecognition.ts
+++ b/src/lib/utils/facialRecognition.ts
@@ -10,6 +10,8 @@ import {
 } from "@aws-sdk/client-rekognition";
 import env from "@/lib/envVariables";
 
+const client: RekognitionClient = new RekognitionClient();
+
 /**
  * Indexes faces in the AWS Collection.
  * @param str Base64 encoded string of an image
@@ -22,7 +24,6 @@ export async function generateFaceprint(str: string) {
     Image: image,
   };
 
-  const client: RekognitionClient = new RekognitionClient();
   const command = new IndexFacesCommand(input);
 
   try {
@@ -45,7 +46,6 @@ export async function searchFaceprint(str: string) {
     Image: image,
     // Keep the other attributes as default
   };
-  const client: RekognitionClient = new RekognitionClient();
   const command = new SearchFacesByImageCommand(input);
   try {
     const results: SearchFacesByImageCommandOutput = await client.send(command);


### PR DESCRIPTION
This PR
- Refactors `facialRecognition.ts` to instantiate the `RekognitionClient` at the module level instead of during each function call
- Fixes some lint complaints

Before: `RekognitionClient` was being created everytime `generateFaceprint` and `searchFaceprint` was called
<img width="1876" height="722" alt="Screenshot 2026-07-04 at 8 59 24 PM" src="https://github.com/user-attachments/assets/1c6da55a-726b-499d-9e0b-13c5ea337fd2" />

After: `RekognitionClient` created once on start up
<img width="1884" height="656" alt="Screenshot 2026-07-04 at 9 06 46 PM" src="https://github.com/user-attachments/assets/b402ee43-723d-48f9-b75a-0864a160f23e" />