### PR TITLE
pin pnpm version and update README accordingly

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -19,7 +19,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 10
           run_install: false
       - run: pnpm install
       - name: Install Vercel CLI

--- a/.github/workflows/vercel-pr-preview.yml
+++ b/.github/workflows/vercel-pr-preview.yml
@@ -21,7 +21,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 10
           run_install: false
       - run: pnpm install
       - name: Install Vercel CLI

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ This is a local-first monorepo for "Project Sa'bai". This guide focuses on getti
 Before you begin, ensure you have the following installed:
 
 1.  **Node.js 20+**: [Download Link](https://nodejs.org/)
-2.  **pnpm**: Recommended package manager.
+2.  **pnpm** (via Corepack): This repo pins its pnpm version in `package.json` (`packageManager` field). Corepack ships with Node.js — enable it once and the correct pnpm version is used automatically:
     ```bash
-    npm install -g pnpm
+    corepack enable
     ```
+    > **Do not** run `npm install -g pnpm`. That installs the latest pnpm (currently v11), which changed how native build scripts are approved and will fail `pnpm install` for this project. Corepack keeps you on the pinned v10.
 3.  **Docker Desktop**: Required for running the local Supabase instance. [Download Link](https://www.docker.com/products/docker-desktop/)
 4.  **Supabase CLI**: Required to manage the local database.
     ```bash

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
+  "packageManager": "pnpm@10.34.4",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
pnpm now has version 11, which causes issues when attempting to install deps. pinned to v10.34.4 in package.json and update README accordingly (which was also missing instructions for installing pnpm). 

Also updated GitHub workflows to automatically use the pnpm version in package.json, instead of choosing a vague v10.

We should discuss in the future whether to migrate to pnpm 11 (the migration looks pretty trivial).