### PR TITLE
134 create consult form

### DIFF
--- a/src/__tests__/components/consults/ConsultForm.test.tsx
+++ b/src/__tests__/components/consults/ConsultForm.test.tsx
@@ -1,0 +1,165 @@
+import { ConsultForm } from "@/components/consults/ConsultForm";
+import { trpc } from "@/utils/trpc";
+import { Toaster, toast } from "react-hot-toast";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/utils/trpc", () => ({
+  trpc: {
+    useUtils: vi.fn(),
+    consultsRouter: {
+      create: { useMutation: vi.fn() },
+    },
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockTrpc = trpc as any;
+
+const VISIT_ID = 10;
+
+// mutate default: invoke the success callback so onSuccess side-effects run
+let mutate: ReturnType<typeof vi.fn>;
+let invalidate: ReturnType<typeof vi.fn>;
+
+function renderForm() {
+  return render(
+    <>
+      <Toaster />
+      <ConsultForm visitId={VISIT_ID} />
+    </>,
+  );
+}
+
+/** Fills the two required text fields and the single diagnosis with valid values. */
+async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/Past Medical History/), "No history");
+  await user.type(screen.getByLabelText(/Consultation/), "Patient is well");
+  await user.click(screen.getByRole("button", { name: "Choose a category" }));
+  await user.click(screen.getByRole("button", { name: "Cardiovascular" }));
+  await user.type(screen.getByLabelText(/Details/), "Hypertension");
+}
+
+describe("ConsultForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toast.remove();
+
+    invalidate = vi.fn();
+    mutate = vi.fn(
+      (
+        _input: unknown,
+        opts?: { onSuccess?: () => void; onError?: () => void },
+      ) => opts?.onSuccess?.(),
+    );
+
+    mockTrpc.useUtils.mockReturnValue({
+      consultsRouter: { getByVisitId: { invalidate } },
+    });
+    mockTrpc.consultsRouter.create.useMutation.mockReturnValue({
+      mutate,
+      isPending: false,
+    });
+  });
+
+  test("renders all fields and the save button", () => {
+    renderForm();
+
+    expect(screen.getByLabelText(/Past Medical History/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Consultation/)).toBeInTheDocument();
+    expect(screen.getByText("Diagnosis 1")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Plan/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Remarks/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save Consult" }),
+    ).toBeInTheDocument();
+  });
+
+  test("blocks submit and shows an error toast when required fields are empty", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Save Consult" }));
+
+    await waitFor(() => {
+      const status = screen.getByRole("status");
+      expect(status.textContent).toBe(
+        "Please fill in all required fields before saving.",
+      );
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  test("submits the mapped payload when the form fields are valid", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: "Save Consult" }));
+
+    await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        visitId: VISIT_ID,
+        pastMedicalHistory: "No history",
+        consultation: "Patient is well",
+        // blank optional fields collapse to undefined
+        treatmentPlan: undefined,
+        remarks: undefined,
+        diagnoses: [{ details: "Hypertension", category: "Cardiovascular" }],
+      }),
+      expect.anything(),
+    );
+  });
+
+  test("does not allow submit when diagnosis fields are empty", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(
+      screen.getByLabelText(/Past Medical History/),
+      "No history",
+    );
+    await user.type(screen.getByLabelText(/Consultation/), "Patient is well");
+
+    await user.click(screen.getByRole("button", { name: "Save Consult" }));
+
+    await waitFor(() => {
+      const status = screen.getByRole("status");
+      expect(status.textContent).toBe(
+        "Please fill in all required fields before saving.",
+      );
+    });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  test("adds and removes diagnosis fields", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    // only one diagnosis: its Remove button is disabled
+    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Add Diagnosis" }));
+    expect(screen.getByText("Diagnosis 2")).toBeInTheDocument();
+
+    // with two, both Remove buttons are enabled; removing one returns to one
+    const removeButtons = screen.getAllByRole("button", { name: "Remove" });
+    expect(removeButtons).toHaveLength(2);
+    await user.click(removeButtons[0]);
+
+    expect(screen.queryByText("Diagnosis 2")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
+  });
+
+  test("shows the save button in a loading state while pending", () => {
+    mockTrpc.consultsRouter.create.useMutation.mockReturnValue({
+      mutate,
+      isPending: true,
+    });
+
+    renderForm();
+
+    expect(screen.getByRole("button", { name: "Save Consult" })).toBeDisabled();
+  });
+});

--- a/src/__tests__/components/consults/ConsultForm.test.tsx
+++ b/src/__tests__/components/consults/ConsultForm.test.tsx
@@ -137,19 +137,23 @@ describe("ConsultForm", () => {
     const user = userEvent.setup();
     renderForm();
 
-    // only one diagnosis: its Remove button is disabled
-    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
+    // only one diagnosis: Remove button is hidden
+    expect(
+      screen.queryByRole("button", { name: "Remove" }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Add Diagnosis" }));
     expect(screen.getByText("Diagnosis 2")).toBeInTheDocument();
 
-    // with two, both Remove buttons are enabled; removing one returns to one
+    // with two, both Remove buttons are visible; removing one hides the button again
     const removeButtons = screen.getAllByRole("button", { name: "Remove" });
     expect(removeButtons).toHaveLength(2);
     await user.click(removeButtons[0]);
 
     expect(screen.queryByText("Diagnosis 2")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Remove" }),
+    ).not.toBeInTheDocument();
   });
 
   test("shows the save button in a loading state while pending", () => {

--- a/src/__tests__/lib/utils/vitals.test.ts
+++ b/src/__tests__/lib/utils/vitals.test.ts
@@ -29,9 +29,14 @@ describe("formatBloodPressure", () => {
     expect(formatBloodPressure(120, 80)).toBe("120 / 80");
   });
 
-  it("uses a dash for missing values", () => {
+  it("uses a dash for an individually missing value", () => {
     expect(formatBloodPressure(null, 80)).toBe("- / 80");
-    expect(formatBloodPressure(undefined, undefined)).toBe("- / -");
+    expect(formatBloodPressure(120, null)).toBe("120 / -");
+  });
+
+  it("collapses to a single dash when both readings are missing", () => {
+    expect(formatBloodPressure(undefined, undefined)).toBe("-");
+    expect(formatBloodPressure(null, null)).toBe("-");
   });
 });
 

--- a/src/__tests__/lib/utils/vitals.test.ts
+++ b/src/__tests__/lib/utils/vitals.test.ts
@@ -1,0 +1,47 @@
+import {
+  computeBmi,
+  formatBloodPressure,
+  formatDiabetes,
+} from "@/lib/utils/vitals";
+
+describe("computeBmi", () => {
+  it("computes BMI to one decimal place", () => {
+    // 70kg at 175cm => 22.857... => "22.9"
+    expect(computeBmi("175", "70")).toBe("22.9");
+  });
+
+  it("returns a placeholder when height is missing", () => {
+    expect(computeBmi(null, "70")).toBe("Invalid/Missing Height or Weight");
+  });
+
+  it("returns a placeholder when weight is missing", () => {
+    expect(computeBmi("175", null)).toBe("Invalid/Missing Height or Weight");
+  });
+
+  it("returns a placeholder for non-numeric or zero values", () => {
+    expect(computeBmi("abc", "70")).toBe("Invalid/Missing Height or Weight");
+    expect(computeBmi("0", "70")).toBe("Invalid/Missing Height or Weight");
+  });
+});
+
+describe("formatBloodPressure", () => {
+  it("formats present readings", () => {
+    expect(formatBloodPressure(120, 80)).toBe("120 / 80");
+  });
+
+  it("uses a dash for missing values", () => {
+    expect(formatBloodPressure(null, 80)).toBe("- / 80");
+    expect(formatBloodPressure(undefined, undefined)).toBe("- / -");
+  });
+});
+
+describe("formatDiabetes", () => {
+  it("maps booleans to Yes/No", () => {
+    expect(formatDiabetes(true)).toBe("Yes");
+    expect(formatDiabetes(false)).toBe("No");
+  });
+
+  it("maps null to the not-asked placeholder", () => {
+    expect(formatDiabetes(null)).toBe("Not Applicable");
+  });
+});

--- a/src/__tests__/lib/utils/vitals.test.ts
+++ b/src/__tests__/lib/utils/vitals.test.ts
@@ -5,9 +5,9 @@ import {
 } from "@/lib/utils/vitals";
 
 describe("computeBmi", () => {
-  it("computes BMI to one decimal place", () => {
-    // 70kg at 175cm => 22.857... => "22.9"
-    expect(computeBmi("175", "70")).toBe("22.9");
+  it("computes BMI to two decimal places", () => {
+    // 70kg at 175cm => 22.857... => "22.86" (rounded to 2 decimal places)
+    expect(computeBmi("175", "70")).toBe("22.86");
   });
 
   it("returns a placeholder when height is missing", () => {

--- a/src/components/consults/ConsultForm.tsx
+++ b/src/components/consults/ConsultForm.tsx
@@ -54,17 +54,30 @@ export function ConsultForm({ visitId }: { visitId: number }) {
     toast.error("Please fill in all required fields before saving.");
 
   const onSubmit = (data: ConsultFormValues) => {
+    const pastMedicalHistory = data.pastMedicalHistory.trim();
+    const consultation = data.consultation.trim();
+    const diagnoses = data.diagnoses.map((d) => ({
+      details: d.details.trim(),
+      category: d.category as DiagnosisCategory,
+    }));
+
+    if (
+      !pastMedicalHistory ||
+      !consultation ||
+      diagnoses.some((d) => !d.details || !d.category)
+    ) {
+      onInvalid();
+      return;
+    }
+
     createConsult.mutate(
       {
         visitId,
-        pastMedicalHistory: data.pastMedicalHistory,
-        consultation: data.consultation,
-        treatmentPlan: data.treatmentPlan || undefined,
-        remarks: data.remarks || undefined,
-        diagnoses: data.diagnoses.map((d) => ({
-          details: d.details,
-          category: d.category as DiagnosisCategory,
-        })),
+        pastMedicalHistory,
+        consultation,
+        treatmentPlan: data.treatmentPlan?.trim() || undefined,
+        remarks: data.remarks?.trim() || undefined,
+        diagnoses,
       },
       {
         onSuccess: () => {

--- a/src/components/consults/ConsultForm.tsx
+++ b/src/components/consults/ConsultForm.tsx
@@ -61,11 +61,7 @@ export function ConsultForm({ visitId }: { visitId: number }) {
       category: d.category as DiagnosisCategory,
     }));
 
-    if (
-      !pastMedicalHistory ||
-      !consultation ||
-      diagnoses.some((d) => !d.details || !d.category)
-    ) {
+    if (diagnoses.some((d) => !d.details || !d.category)) {
       onInvalid();
       return;
     }
@@ -73,8 +69,8 @@ export function ConsultForm({ visitId }: { visitId: number }) {
     createConsult.mutate(
       {
         visitId,
-        pastMedicalHistory,
-        consultation,
+        pastMedicalHistory: pastMedicalHistory || undefined,
+        consultation: consultation || undefined,
         treatmentPlan: data.treatmentPlan?.trim() || undefined,
         remarks: data.remarks?.trim() || undefined,
         diagnoses,
@@ -101,14 +97,12 @@ export function ConsultForm({ visitId }: { visitId: number }) {
           <RHFTextArea
             name="pastMedicalHistory"
             label="Past Medical History"
-            isRequired
             rows={3}
             placeholder="Type the patient's past medical history here..."
           />
           <RHFTextArea
             name="consultation"
             label="Consultation"
-            isRequired
             rows={4}
             placeholder="Type your consultation here..."
           />

--- a/src/components/consults/ConsultForm.tsx
+++ b/src/components/consults/ConsultForm.tsx
@@ -132,16 +132,17 @@ export function ConsultForm({ visitId }: { visitId: number }) {
                 <p className="text-sm font-semibold text-slate-600">
                   Diagnosis {index + 1}
                 </p>
-                <button
-                  type="button"
-                  onClick={() => remove(index)}
-                  disabled={fields.length === 1}
-                  title="Remove diagnosis"
-                  className="inline-flex items-center gap-1 rounded p-1 text-sm text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-transparent"
-                >
-                  <HiOutlineTrash className="h-4 w-4" />
-                  Remove
-                </button>
+                {fields.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => remove(index)}
+                    title="Remove diagnosis"
+                    className="inline-flex items-center gap-1 rounded p-1 text-sm text-red-600 transition hover:bg-red-50"
+                  >
+                    <HiOutlineTrash className="h-4 w-4" />
+                    Remove
+                  </button>
+                )}
               </div>
               <RHFDropdown
                 name={`diagnoses.${index}.category`}

--- a/src/components/consults/ConsultForm.tsx
+++ b/src/components/consults/ConsultForm.tsx
@@ -1,4 +1,4 @@
-import { useFieldArray, useFormContext } from "react-hook-form";
+import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { HiOutlineTrash } from "react-icons/hi2";
 import { trpc } from "@/utils/trpc";
@@ -33,21 +33,14 @@ export const BLANK_CONSULT: ConsultFormValues = {
 };
 
 /**
- * The consultation form body. Must be rendered inside a `FormProvider`.
- *
- * Submits the consult and all diagnoses in one transaction.
+ * The consultation form for a single visit. Owns its own form state.
+ * Remount via `key` (e.g. per visit) to get a fresh form.
  *
  * @param visitId - The visit this consult belongs to.
- * @param onSaved - Called after a successful save so the form can be reset.
  */
-export function ConsultForm({
-  visitId,
-  onSaved,
-}: {
-  visitId: number;
-  onSaved: () => void;
-}) {
-  const { control, handleSubmit } = useFormContext<ConsultFormValues>();
+export function ConsultForm({ visitId }: { visitId: number }) {
+  const methods = useForm<ConsultFormValues>({ defaultValues: BLANK_CONSULT });
+  const { control, handleSubmit } = methods;
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -76,8 +69,8 @@ export function ConsultForm({
       {
         onSuccess: () => {
           utils.consultsRouter.getByVisitId.invalidate({ visitId });
-          toast.success("Consult saved successfully!");
-          onSaved();
+          toast.success("Consult has been saved successfully!");
+          methods.reset(BLANK_CONSULT);
         },
         onError: () => toast.error("Failed to save consult."),
       },
@@ -85,107 +78,109 @@ export function ConsultForm({
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="space-y-8">
-      <h2 className="text-lg font-semibold text-slate-900">
-        Doctor&apos;s Consult Form
-      </h2>
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="space-y-8">
+        <h2 className="text-lg font-semibold text-slate-900">
+          Doctor&apos;s Consult Form
+        </h2>
 
-      <section className="space-y-4">
-        <RHFTextArea
-          name="pastMedicalHistory"
-          label="Past Medical History"
-          isRequired
-          rows={3}
-          placeholder="Type the patient's past medical history here..."
-        />
-        <RHFTextArea
-          name="consultation"
-          label="Consultation"
-          isRequired
-          rows={4}
-          placeholder="Type your consultation here..."
-        />
-      </section>
+        <section className="space-y-4">
+          <RHFTextArea
+            name="pastMedicalHistory"
+            label="Past Medical History"
+            isRequired
+            rows={3}
+            placeholder="Type the patient's past medical history here..."
+          />
+          <RHFTextArea
+            name="consultation"
+            label="Consultation"
+            isRequired
+            rows={4}
+            placeholder="Type your consultation here..."
+          />
+        </section>
 
-      <section className="space-y-4">
-        <div className="flex items-center gap-1">
-          <h3 className="text-sm font-semibold text-slate-700">Diagnoses</h3>
-          <IsRequiredStar isRequired />
-        </div>
-
-        <Button
-          type="button"
-          title="Add Diagnosis"
-          colour="emerald"
-          variant="filled"
-          onClick={() => append({ details: "", category: "" })}
-          className="w-full"
-        />
-
-        {fields.map((field, index) => (
-          <div
-            key={field.id}
-            className="space-y-4 rounded-lg border border-slate-200 p-4"
-          >
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-semibold text-slate-600">
-                Diagnosis {index + 1}
-              </p>
-              <button
-                type="button"
-                onClick={() => remove(index)}
-                disabled={fields.length === 1}
-                title="Remove diagnosis"
-                className="inline-flex items-center gap-1 rounded p-1 text-sm text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-transparent"
-              >
-                <HiOutlineTrash className="h-4 w-4" />
-                Remove
-              </button>
-            </div>
-            <RHFDropdown
-              name={`diagnoses.${index}.category`}
-              label="Category"
-              dropdownOptions={DIAGNOSIS_CATEGORY_OPTIONS}
-              isRequired
-              placeholder="Choose a category"
-            />
-            <RHFTextArea
-              name={`diagnoses.${index}.details`}
-              label="Details"
-              isRequired
-              rows={2}
-              placeholder="Describe the diagnosis..."
-            />
+        <section className="space-y-4">
+          <div className="flex items-center gap-1">
+            <h3 className="text-sm font-semibold text-slate-700">Diagnoses</h3>
+            <IsRequiredStar isRequired />
           </div>
-        ))}
-      </section>
 
-      <section className="space-y-4">
-        <RHFTextArea
-          name="treatmentPlan"
-          label="Plan"
-          rows={3}
-          placeholder="Type your plan here..."
-        />
-        <RHFTextArea
-          name="remarks"
-          label="Remarks"
-          rows={2}
-          placeholder="Type your remarks here..."
-        />
-      </section>
-
-      <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-end">
-        <div className="w-full sm:w-44">
           <Button
-            type="submit"
-            title="Save Consult"
+            type="button"
+            title="Add Diagnosis"
             colour="emerald"
             variant="filled"
-            loading={createConsult.isPending}
+            onClick={() => append({ details: "", category: "" })}
+            className="w-full"
           />
+
+          {fields.map((field, index) => (
+            <div
+              key={field.id}
+              className="space-y-4 rounded-lg border border-slate-200 p-4"
+            >
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-slate-600">
+                  Diagnosis {index + 1}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  disabled={fields.length === 1}
+                  title="Remove diagnosis"
+                  className="inline-flex items-center gap-1 rounded p-1 text-sm text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-transparent"
+                >
+                  <HiOutlineTrash className="h-4 w-4" />
+                  Remove
+                </button>
+              </div>
+              <RHFDropdown
+                name={`diagnoses.${index}.category`}
+                label="Category"
+                dropdownOptions={DIAGNOSIS_CATEGORY_OPTIONS}
+                isRequired
+                placeholder="Choose a category"
+              />
+              <RHFTextArea
+                name={`diagnoses.${index}.details`}
+                label="Details"
+                isRequired
+                rows={2}
+                placeholder="Describe the diagnosis..."
+              />
+            </div>
+          ))}
+        </section>
+
+        <section className="space-y-4">
+          <RHFTextArea
+            name="treatmentPlan"
+            label="Plan"
+            rows={3}
+            placeholder="Type your plan here..."
+          />
+          <RHFTextArea
+            name="remarks"
+            label="Remarks"
+            rows={2}
+            placeholder="Type your remarks here..."
+          />
+        </section>
+
+        <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-end">
+          <div className="w-full sm:w-44">
+            <Button
+              type="submit"
+              title="Save Consult"
+              colour="emerald"
+              variant="filled"
+              loading={createConsult.isPending}
+            />
+          </div>
         </div>
-      </div>
-    </form>
+      </form>
+    </FormProvider>
   );
 }

--- a/src/components/consults/ConsultForm.tsx
+++ b/src/components/consults/ConsultForm.tsx
@@ -1,0 +1,191 @@
+import { useFieldArray, useFormContext } from "react-hook-form";
+import toast from "react-hot-toast";
+import { HiOutlineTrash } from "react-icons/hi2";
+import { trpc } from "@/utils/trpc";
+import { RHFTextArea } from "@/components/interactive/RHF/RHFTextArea";
+import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
+import { Button } from "@/components/interactive/Button/Button";
+import { IsRequiredStar } from "@/components/IsRequiredStar";
+import {
+  DIAGNOSIS_CATEGORY_OPTIONS,
+  DiagnosisCategory,
+} from "@/lib/constants/diagnosisCategories";
+
+export type DiagnosisFormValue = {
+  details: string;
+  category: string;
+};
+
+export type ConsultFormValues = {
+  pastMedicalHistory: string;
+  consultation: string;
+  treatmentPlan: string;
+  remarks: string;
+  diagnoses: DiagnosisFormValue[];
+};
+
+export const BLANK_CONSULT: ConsultFormValues = {
+  pastMedicalHistory: "",
+  consultation: "",
+  treatmentPlan: "",
+  remarks: "",
+  diagnoses: [{ details: "", category: "" }],
+};
+
+/**
+ * The consultation form body. Must be rendered inside a `FormProvider`.
+ *
+ * Submits the consult and all diagnoses in one transaction.
+ *
+ * @param visitId - The visit this consult belongs to.
+ * @param onSaved - Called after a successful save so the form can be reset.
+ */
+export function ConsultForm({
+  visitId,
+  onSaved,
+}: {
+  visitId: number;
+  onSaved: () => void;
+}) {
+  const { control, handleSubmit } = useFormContext<ConsultFormValues>();
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "diagnoses",
+  });
+
+  const utils = trpc.useUtils();
+  const createConsult = trpc.consultsRouter.create.useMutation();
+
+  const onInvalid = () =>
+    toast.error("Please fill in all required fields before saving.");
+
+  const onSubmit = (data: ConsultFormValues) => {
+    createConsult.mutate(
+      {
+        visitId,
+        pastMedicalHistory: data.pastMedicalHistory,
+        consultation: data.consultation,
+        treatmentPlan: data.treatmentPlan || undefined,
+        remarks: data.remarks || undefined,
+        diagnoses: data.diagnoses.map((d) => ({
+          details: d.details,
+          category: d.category as DiagnosisCategory,
+        })),
+      },
+      {
+        onSuccess: () => {
+          utils.consultsRouter.getByVisitId.invalidate({ visitId });
+          toast.success("Consult saved successfully!");
+          onSaved();
+        },
+        onError: () => toast.error("Failed to save consult."),
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="space-y-8">
+      <h2 className="text-lg font-semibold text-slate-900">
+        Doctor&apos;s Consult Form
+      </h2>
+
+      <section className="space-y-4">
+        <RHFTextArea
+          name="pastMedicalHistory"
+          label="Past Medical History"
+          isRequired
+          rows={3}
+          placeholder="Type the patient's past medical history here..."
+        />
+        <RHFTextArea
+          name="consultation"
+          label="Consultation"
+          isRequired
+          rows={4}
+          placeholder="Type your consultation here..."
+        />
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center gap-1">
+          <h3 className="text-sm font-semibold text-slate-700">Diagnoses</h3>
+          <IsRequiredStar isRequired />
+        </div>
+
+        <Button
+          type="button"
+          title="Add Diagnosis"
+          colour="emerald"
+          variant="filled"
+          onClick={() => append({ details: "", category: "" })}
+          className="w-full"
+        />
+
+        {fields.map((field, index) => (
+          <div
+            key={field.id}
+            className="space-y-4 rounded-lg border border-slate-200 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold text-slate-600">
+                Diagnosis {index + 1}
+              </p>
+              <button
+                type="button"
+                onClick={() => remove(index)}
+                disabled={fields.length === 1}
+                title="Remove diagnosis"
+                className="inline-flex items-center gap-1 rounded p-1 text-sm text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-transparent"
+              >
+                <HiOutlineTrash className="h-4 w-4" />
+                Remove
+              </button>
+            </div>
+            <RHFDropdown
+              name={`diagnoses.${index}.category`}
+              label="Category"
+              dropdownOptions={DIAGNOSIS_CATEGORY_OPTIONS}
+              isRequired
+              placeholder="Choose a category"
+            />
+            <RHFTextArea
+              name={`diagnoses.${index}.details`}
+              label="Details"
+              isRequired
+              rows={2}
+              placeholder="Describe the diagnosis..."
+            />
+          </div>
+        ))}
+      </section>
+
+      <section className="space-y-4">
+        <RHFTextArea
+          name="treatmentPlan"
+          label="Plan"
+          rows={3}
+          placeholder="Type your plan here..."
+        />
+        <RHFTextArea
+          name="remarks"
+          label="Remarks"
+          rows={2}
+          placeholder="Type your remarks here..."
+        />
+      </section>
+
+      <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-end">
+        <div className="w-full sm:w-44">
+          <Button
+            type="submit"
+            title="Save Consult"
+            colour="emerald"
+            variant="filled"
+            loading={createConsult.isPending}
+          />
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/consults/PreviousConsults.tsx
+++ b/src/components/consults/PreviousConsults.tsx
@@ -12,7 +12,9 @@ function Field({ label, value }: { label: string; value: string | null }) {
   if (!value) return null;
   return (
     <div>
-      <p className="text-xs font-semibold text-slate-500">{label}</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+        {label}
+      </p>
       <p className="whitespace-pre-wrap break-words text-sm text-slate-700">
         {value}
       </p>
@@ -34,7 +36,9 @@ function ConsultCard({ consult }: { consult: Consult }) {
 
       {consult.diagnoses.length > 0 && (
         <div>
-          <p className="text-xs font-semibold text-slate-500">Diagnoses</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+            Diagnoses
+          </p>
           <ul className="mt-1 space-y-1">
             {consult.diagnoses.map((d) => (
               <li key={d.id} className="break-words text-sm text-slate-700">

--- a/src/components/consults/PreviousConsults.tsx
+++ b/src/components/consults/PreviousConsults.tsx
@@ -1,0 +1,86 @@
+import { trpc, RouterOutput } from "@/utils/trpc";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import { formatVisitDate } from "@/lib/utils/visit";
+
+type Consult = RouterOutput["consultsRouter"]["getByVisitId"][number];
+
+/**
+ * A single labelled block of read-only consult text. Renders nothing when the
+ * value is empty so blank optional fields don't clutter the card.
+ */
+function Field({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null;
+  return (
+    <div>
+      <p className="text-xs font-semibold text-slate-500">{label}</p>
+      <p className="whitespace-pre-wrap break-words text-sm text-slate-700">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * A read-only card for one saved consult: its date, notes, and diagnoses.
+ */
+function ConsultCard({ consult }: { consult: Consult }) {
+  return (
+    <article className="space-y-3 rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-400">
+        {formatVisitDate(consult.date)}
+      </p>
+      <Field label="Past Medical History" value={consult.pastMedicalHistory} />
+      <Field label="Consultation" value={consult.consultation} />
+
+      {consult.diagnoses.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-slate-500">Diagnoses</p>
+          <ul className="mt-1 space-y-1">
+            {consult.diagnoses.map((d) => (
+              <li key={d.id} className="break-words text-sm text-slate-700">
+                <span className="font-medium">{d.category ?? "—"}:</span>{" "}
+                {d.details}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <Field label="Plan" value={consult.treatmentPlan} />
+      <Field label="Remarks" value={consult.remarks} />
+    </article>
+  );
+}
+
+/**
+ * Read-only list of previously-saved consults for a visit, most recent first.
+ * A visit can accumulate multiple consults (append log), so this shows the
+ * history alongside the form for recording a new one.
+ */
+export function PreviousConsults({ visitId }: { visitId: number }) {
+  const { data: consults, isLoading } =
+    trpc.consultsRouter.getByVisitId.useQuery({ visitId });
+
+  if (isLoading) {
+    return (
+      <LoadingSpinner message="Loading previous consults..." className="p-6" />
+    );
+  }
+
+  if (!consults || consults.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-8 space-y-4 border-t border-slate-200 pt-8">
+      <h2 className="text-sm font-semibold text-slate-700">
+        Previous Consults ({consults.length})
+      </h2>
+      <div className="space-y-4">
+        {consults.map((consult) => (
+          <ConsultCard key={consult.id} consult={consult} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/consults/PreviousConsults.tsx
+++ b/src/components/consults/PreviousConsults.tsx
@@ -38,7 +38,7 @@ function ConsultCard({ consult }: { consult: Consult }) {
           <ul className="mt-1 space-y-1">
             {consult.diagnoses.map((d) => (
               <li key={d.id} className="break-words text-sm text-slate-700">
-                <span className="font-medium">{d.category ?? "—"}:</span>{" "}
+                <span className="font-medium">{d.category ?? "-"}:</span>{" "}
                 {d.details}
               </li>
             ))}

--- a/src/components/consults/PreviousConsults.tsx
+++ b/src/components/consults/PreviousConsults.tsx
@@ -74,7 +74,7 @@ export function PreviousConsults({ visitId }: { visitId: number }) {
   return (
     <section className="mt-8 space-y-4 border-t border-slate-200 pt-8">
       <h2 className="text-sm font-semibold text-slate-700">
-        Previous Consults ({consults.length})
+        Previous consults from this visit ({consults.length})
       </h2>
       <div className="space-y-4">
         {consults.map((consult) => (

--- a/src/components/consults/VisitSummaryPanel.tsx
+++ b/src/components/consults/VisitSummaryPanel.tsx
@@ -54,63 +54,80 @@ export function VisitSummaryPanel({ visitId }: { visitId: number }) {
     <div className="space-y-8">
       <section className="space-y-4">
         <h2 className="text-sm font-semibold text-slate-700">Vitals</h2>
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-          <ReadOnlyField label="Height" value={vitals?.height} />
-          <ReadOnlyField label="Weight" value={vitals?.weight} />
-          <ReadOnlyField
-            label="BMI"
-            value={computeBmi(vitals?.height ?? null, vitals?.weight ?? null)}
-          />
-          <ReadOnlyField
-            label="Blood Pressure (Systolic / Diastolic) / mmHg"
-            value={bloodPressure}
-          />
+        {vitals === null ? (
+          <p className="text-sm text-slate-500">
+            No vitals recorded for this visit.
+          </p>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+              <ReadOnlyField label="Height" value={vitals?.height} />
+              <ReadOnlyField label="Weight" value={vitals?.weight} />
+              <ReadOnlyField
+                label="BMI"
+                value={computeBmi(
+                  vitals?.height ?? null,
+                  vitals?.weight ?? null,
+                )}
+              />
+              <ReadOnlyField
+                label="Blood Pressure (Systolic / Diastolic) / mmHg"
+                value={bloodPressure}
+              />
 
-          <ReadOnlyField label="Heart Rate" value={vitals?.heartRate} />
-          <ReadOnlyField label="Temperature" value={vitals?.temperature} />
-          <ReadOnlyField label="Urine Dip Test" value={vitals?.urineTest} />
-          <ReadOnlyField
-            label="Hemocue Hb Count"
-            value={vitals?.hemocueCount}
-          />
+              <ReadOnlyField label="Heart Rate" value={vitals?.heartRate} />
+              <ReadOnlyField label="Temperature" value={vitals?.temperature} />
+              <ReadOnlyField label="Urine Dip Test" value={vitals?.urineTest} />
+              <ReadOnlyField
+                label="Hemocue Hb Count"
+                value={vitals?.hemocueCount}
+              />
 
-          <ReadOnlyField
-            label="Non-Fasting Blood Glucose"
-            value={vitals?.bloodGlucoseNonFasting}
-          />
-          <ReadOnlyField
-            label="Fasting Blood Glucose"
-            value={vitals?.bloodGlucoseFasting}
-          />
-          <ReadOnlyField label="HbA1c" value={vitals?.hba1c} />
-          <ReadOnlyField
-            label="Diabetes Mellitus?"
-            value={formatDiabetes(vitals?.diabetesMellitus ?? null)}
-          />
-        </div>
+              <ReadOnlyField
+                label="Non-Fasting Blood Glucose"
+                value={vitals?.bloodGlucoseNonFasting}
+              />
+              <ReadOnlyField
+                label="Fasting Blood Glucose"
+                value={vitals?.bloodGlucoseFasting}
+              />
+              <ReadOnlyField label="HbA1c" value={vitals?.hba1c} />
+              <ReadOnlyField
+                label="Diabetes Mellitus?"
+                value={formatDiabetes(vitals?.diabetesMellitus ?? null)}
+              />
+            </div>
 
-        <ReadOnlyField
-          label="Others"
-          value={vitals?.others}
-          className="w-full"
-        />
+            <ReadOnlyField
+              label="Others"
+              value={vitals?.others}
+              className="w-full"
+            />
+          </>
+        )}
       </section>
 
       {/* Eyesight / Vision section */}
       <section className="space-y-4">
         <h2 className="text-sm font-semibold text-slate-700">Vision</h2>
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-          <ReadOnlyField label="Right Eye" value={eyesight?.rightEyeDegree} />
-          <ReadOnlyField label="Left Eye" value={eyesight?.leftEyeDegree} />
-          <ReadOnlyField
-            label="Right Eye Pinhole"
-            value={eyesight?.rightEyePinhole}
-          />
-          <ReadOnlyField
-            label="Left Eye Pinhole"
-            value={eyesight?.leftEyePinhole}
-          />
-        </div>
+        {eyesight === null ? (
+          <p className="text-sm text-slate-500">
+            No vision recorded for this visit.
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            <ReadOnlyField label="Right Eye" value={eyesight?.rightEyeDegree} />
+            <ReadOnlyField label="Left Eye" value={eyesight?.leftEyeDegree} />
+            <ReadOnlyField
+              label="Right Eye Pinhole"
+              value={eyesight?.rightEyePinhole}
+            />
+            <ReadOnlyField
+              label="Left Eye Pinhole"
+              value={eyesight?.leftEyePinhole}
+            />
+          </div>
+        )}
       </section>
     </div>
   );

--- a/src/components/consults/VisitSummaryPanel.tsx
+++ b/src/components/consults/VisitSummaryPanel.tsx
@@ -1,0 +1,117 @@
+import { ReactNode } from "react";
+import { trpc } from "@/utils/trpc";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import {
+  computeBmi,
+  formatBloodPressure,
+  formatDiabetes,
+} from "@/lib/utils/vitals";
+
+/**
+ * A single read-only vitals field
+ */
+function ReadOnlyField({
+  label,
+  value,
+  className = "",
+}: {
+  label: string;
+  value: ReactNode;
+  className?: string;
+}) {
+  const isEmpty =
+    value === null || value === undefined || value === "" || value === "-";
+  return (
+    <div className={className}>
+      <p className="mb-1 text-sm font-bold text-slate-900">{label}</p>
+      <div className="min-h-[2.5rem] rounded bg-slate-100 px-3 py-2 text-sm text-slate-700">
+        {isEmpty ? "-" : value}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Read-only panel showing the vitals and vision (eyesight) recorded for a
+ * visit, displayed alongside consult form for doctor / medical student to reference.
+ */
+export function VisitSummaryPanel({ visitId }: { visitId: number }) {
+  const { data: vitals, isLoading: vitalsLoading } =
+    trpc.vitalsRouter.getByVisitId.useQuery({ visitId });
+  const { data: eyesight, isLoading: eyesightLoading } =
+    trpc.eyesightRouter.getByVisitId.useQuery({ visitId });
+
+  if (vitalsLoading || eyesightLoading) {
+    return <LoadingSpinner message="Loading vitals..." className="p-6" />;
+  }
+
+  const bloodPressure = formatBloodPressure(
+    vitals?.systolic,
+    vitals?.diastolic,
+  );
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-slate-700">Vitals</h2>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <ReadOnlyField label="Height" value={vitals?.height} />
+          <ReadOnlyField label="Weight" value={vitals?.weight} />
+          <ReadOnlyField
+            label="BMI"
+            value={computeBmi(vitals?.height ?? null, vitals?.weight ?? null)}
+          />
+          <ReadOnlyField
+            label="Blood Pressure (Systolic / Diastolic) / mmHg"
+            value={bloodPressure}
+          />
+
+          <ReadOnlyField label="Heart Rate" value={vitals?.heartRate} />
+          <ReadOnlyField label="Temperature" value={vitals?.temperature} />
+          <ReadOnlyField label="Urine Dip Test" value={vitals?.urineTest} />
+          <ReadOnlyField
+            label="Hemocue Hb Count"
+            value={vitals?.hemocueCount}
+          />
+
+          <ReadOnlyField
+            label="Non-Fasting Blood Glucose"
+            value={vitals?.bloodGlucoseNonFasting}
+          />
+          <ReadOnlyField
+            label="Fasting Blood Glucose"
+            value={vitals?.bloodGlucoseFasting}
+          />
+          <ReadOnlyField label="HbA1c" value={vitals?.hba1c} />
+          <ReadOnlyField
+            label="Diabetes Mellitus?"
+            value={formatDiabetes(vitals?.diabetesMellitus ?? null)}
+          />
+        </div>
+
+        <ReadOnlyField
+          label="Others"
+          value={vitals?.others}
+          className="w-full"
+        />
+      </section>
+
+      {/* Eyesight / Vision section */}
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-slate-700">Vision</h2>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <ReadOnlyField label="Right Eye" value={eyesight?.rightEyeDegree} />
+          <ReadOnlyField label="Left Eye" value={eyesight?.leftEyeDegree} />
+          <ReadOnlyField
+            label="Right Eye Pinhole"
+            value={eyesight?.rightEyePinhole}
+          />
+          <ReadOnlyField
+            label="Left Eye Pinhole"
+            value={eyesight?.leftEyePinhole}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/lib/supabaseClient";
 import { AiOutlineSetting, AiOutlineUser } from "react-icons/ai";
 import { BsEyeglasses } from "react-icons/bs";
 import { MdMonitorHeart } from "react-icons/md";
+import { FaStethoscope } from "react-icons/fa";
 import { PiSignOutFill } from "react-icons/pi";
 import { IoMdMenu } from "react-icons/io";
 import { LuScanFace } from "react-icons/lu";
@@ -75,6 +76,7 @@ function SidebarNavButtons() {
     { name: "Patient", href: "/patient", icon: AiOutlineUser },
     { name: "Vitals", href: "/vitals", icon: MdMonitorHeart },
     { name: "Vision", href: "/vision", icon: BsEyeglasses },
+    { name: "Consults", href: "/consults", icon: FaStethoscope },
     {
       name: "Medication Stock",
       href: "/medication-stock",

--- a/src/lib/constants/diagnosisCategories.ts
+++ b/src/lib/constants/diagnosisCategories.ts
@@ -1,0 +1,36 @@
+import type { DropdownOption } from "@/components/interactive/RHF/RHFDropdown";
+
+/**
+ * Clinical list of diagnosis categories.
+ *
+ * To be SSOT (Single Source of Truth) shared between the client dropdown and the
+ * server-side validation.
+ */
+export const DIAGNOSIS_CATEGORIES = [
+  "Cardiovascular",
+  "Dermatology",
+  "Ear Nose Throat",
+  "Endocrine",
+  "Eye",
+  "Gastrointestinal",
+  "Haematology",
+  "Infectious Diseases",
+  "Renal & Genitourinary",
+  "Respiratory",
+  "Musculoskeletal",
+  "Neurology",
+  "Obstetrics & Gynaecology",
+  "Oral Health",
+  "Others",
+] as const;
+
+export type DiagnosisCategory = (typeof DIAGNOSIS_CATEGORIES)[number];
+
+/**
+ * The diagnosis categories formatted as RHFDropdown options.
+ */
+export const DIAGNOSIS_CATEGORY_OPTIONS: DropdownOption[] =
+  DIAGNOSIS_CATEGORIES.map((category) => ({
+    label: category,
+    value: category,
+  }));

--- a/src/lib/utils/vitals.ts
+++ b/src/lib/utils/vitals.ts
@@ -16,12 +16,15 @@ export function computeBmi(
 }
 
 /**
- * Formats systolic/diastolic readings as "120 / 80", using a dash for any missing value.
+ * Formats systolic/diastolic readings as "120 / 80", using a dash for an
+ * individually missing value. When both are missing, returns a single "-" so it
+ * matches the placeholder used for every other empty vital.
  */
 export function formatBloodPressure(
   systolic: number | null | undefined,
   diastolic: number | null | undefined,
 ): string {
+  if (systolic == null && diastolic == null) return "-";
   return `${systolic ?? "-"} / ${diastolic ?? "-"}`;
 }
 

--- a/src/lib/utils/vitals.ts
+++ b/src/lib/utils/vitals.ts
@@ -1,0 +1,36 @@
+/**
+ * Computes BMI from height (cm) and weight (kg), or an explanatory string when either measurement is missing/invalid.
+ * Formula for BMI: weight (kg) / (height (m) * height (m))
+ */
+export function computeBmi(
+  height: string | null,
+  weight: string | null,
+): string {
+  const h = height ? Number(height) : NaN;
+  const w = weight ? Number(weight) : NaN;
+  if (!h || !w || Number.isNaN(h) || Number.isNaN(w)) {
+    return "Invalid/Missing Height or Weight";
+  }
+  const metres = h / 100;
+  return (w / (metres * metres)).toFixed(2);
+}
+
+/**
+ * Formats systolic/diastolic readings as "120 / 80", using a dash for any missing value.
+ */
+export function formatBloodPressure(
+  systolic: number | null | undefined,
+  diastolic: number | null | undefined,
+): string {
+  return `${systolic ?? "-"} / ${diastolic ?? "-"}`;
+}
+
+/**
+ * Formats the nullable "diabetes mellitus" tri-state used in the legacy app.
+ */
+export function formatDiabetes(value: boolean | null): string {
+  if (value === null || value === undefined) {
+    return "Not Applicable";
+  }
+  return value ? "Yes" : "No";
+}

--- a/src/pages/consults/[patientId].tsx
+++ b/src/pages/consults/[patientId].tsx
@@ -1,0 +1,135 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
+import withDefaultLayout from "@/components/layouts/withDefaultLayout";
+import Breadcrumbs from "@/components/Breadcrumbs";
+import { trpc } from "@/utils/trpc";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
+import { formatVisitDate } from "@/lib/utils/visit";
+import { formatPatientId } from "@/lib/utils/patient";
+import { ConsultForm } from "@/components/consults/ConsultForm";
+import { VisitSummaryPanel } from "@/components/consults/VisitSummaryPanel";
+
+function ConsultsPage() {
+  const router = useRouter();
+  const { patientId } = router.query;
+
+  // A small form just for the visit selector so it can use `RHFDropdown`.
+  const visitForm = useForm<{ visitSelect: string }>({
+    defaultValues: { visitSelect: "" },
+  });
+  const selectedVisitValue = useWatch({
+    control: visitForm.control,
+    name: "visitSelect",
+  });
+  const selectedVisitId = selectedVisitValue
+    ? Number(selectedVisitValue)
+    : null;
+
+  const { data: patient, isLoading: patientLoading } =
+    trpc.patientsRouter.getById.useQuery(
+      { id: Number(patientId) },
+      { enabled: !!patientId },
+    );
+
+  const { data: visits, isLoading: visitsLoading } =
+    trpc.visitsRouter.getByPatientId.useQuery(
+      { patientId: Number(patientId) },
+      { enabled: !!patientId },
+    );
+
+  // Auto-select the visit when there is only one.
+  useEffect(() => {
+    if (visits && visits.length === 1) {
+      visitForm.setValue("visitSelect", visits[0].id.toString());
+    }
+  }, [visits, visitForm]);
+
+  if (!router.isReady || patientLoading || visitsLoading) {
+    return (
+      <LoadingSpinner
+        message="Loading patient and visits..."
+        className="p-12"
+      />
+    );
+  }
+
+  if (!patient) {
+    return (
+      <div className="p-8 text-center font-semibold text-red-500">
+        Patient not found
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex-1 bg-slate-50 p-8">
+      <div className="mx-auto w-full max-w-7xl">
+        <Breadcrumbs
+          items={[
+            { label: "Home", href: "/" },
+            { label: "Consults", href: "/consults" },
+            { label: `Consult — ${patient.name}` },
+          ]}
+        />
+
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-slate-900">
+            Consult — {patient.name}
+          </h1>
+          <p className="mt-2 text-slate-600">
+            Patient ID: {formatPatientId(patient.id)}
+          </p>
+        </div>
+
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="border-b border-slate-100 bg-slate-50/50 p-6">
+            {visits && visits.length > 0 ? (
+              <div className="w-full max-w-md">
+                <FormProvider {...visitForm}>
+                  <RHFDropdown
+                    name="visitSelect"
+                    label="Choose visit"
+                    placeholder="Select a visit"
+                    dropdownOptions={visits.map((visit) => ({
+                      label: formatVisitDate(visit.date),
+                      value: visit.id.toString(),
+                    }))}
+                  />
+                </FormProvider>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-700">
+                No visits found for this patient. Please create a visit first to
+                record a consult.
+              </div>
+            )}
+          </div>
+
+          <div className="p-6">
+            {selectedVisitId ? (
+              <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+                <aside className="lg:border-r lg:border-slate-100 lg:pr-8">
+                  <VisitSummaryPanel visitId={selectedVisitId} />
+                </aside>
+                <ConsultForm key={selectedVisitId} visitId={selectedVisitId} />
+              </div>
+            ) : (
+              visits &&
+              visits.length > 0 && (
+                <div className="rounded-xl border-2 border-dashed border-slate-200 py-12 text-center font-medium text-slate-400">
+                  Please choose a visit to record a consult.
+                </div>
+              )
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ConsultsPage.getLayout = (page: React.ReactNode) => withDefaultLayout(page);
+
+export default ConsultsPage;

--- a/src/pages/consults/[patientId].tsx
+++ b/src/pages/consults/[patientId].tsx
@@ -9,6 +9,7 @@ import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
 import { formatVisitDate } from "@/lib/utils/visit";
 import { formatPatientId } from "@/lib/utils/patient";
 import { ConsultForm } from "@/components/consults/ConsultForm";
+import { PreviousConsults } from "@/components/consults/PreviousConsults";
 import { VisitSummaryPanel } from "@/components/consults/VisitSummaryPanel";
 
 function ConsultsPage() {
@@ -110,8 +111,9 @@ function ConsultsPage() {
           <div className="p-6">
             {selectedVisitId ? (
               <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-                <aside className="lg:border-r lg:border-slate-100 lg:pr-8">
+                <aside className="min-w-0 lg:border-r lg:border-slate-100 lg:pr-8">
                   <VisitSummaryPanel visitId={selectedVisitId} />
+                  <PreviousConsults visitId={selectedVisitId} />
                 </aside>
                 <ConsultForm key={selectedVisitId} visitId={selectedVisitId} />
               </div>

--- a/src/pages/consults/index.tsx
+++ b/src/pages/consults/index.tsx
@@ -1,0 +1,111 @@
+import { ReactNode } from "react";
+import { useRouter } from "next/router";
+import { HiOutlinePencilSquare } from "react-icons/hi2";
+import withDefaultLayout from "@/components/layouts/withDefaultLayout";
+import Breadcrumbs from "@/components/Breadcrumbs";
+import { trpc } from "@/utils/trpc";
+import { PatientPhoto } from "@/components/PatientPhoto";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import TableHeader from "@/components/TableHeader";
+import TableRow from "@/components/TableRow";
+import TableCell from "@/components/TableCell";
+import { formatPatientCode } from "@/lib/utils/patient";
+
+function ConsultsPage() {
+  const router = useRouter();
+  const {
+    data: patients,
+    isLoading,
+    isError,
+  } = trpc.patientsRouter.list.useQuery();
+
+  const startConsult = (patientId: number) =>
+    router.push(`/consults/${patientId}`);
+
+  function renderContent() {
+    if (isError) {
+      return <h1 className="text-red-500">An error has occurred!</h1>;
+    }
+
+    if (isLoading) {
+      return <LoadingSpinner message="Loading patients..." className="p-12" />;
+    }
+
+    if (!patients || patients.length === 0) {
+      return (
+        <div className="p-12 text-center text-slate-500">
+          No patients found. Add patients to record consults.
+        </div>
+      );
+    }
+
+    return (
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200">
+          <TableHeader headers={["ID", "Photo", "Name", "Actions"]} />
+          <tbody className="divide-y divide-slate-200 bg-white">
+            {patients.map((patient) => (
+              <TableRow key={patient.id}>
+                <TableCell>
+                  <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-900">
+                    {patient.villageColorHex && (
+                      <span
+                        className="h-3 w-3 rounded-full"
+                        style={{ backgroundColor: patient.villageColorHex }}
+                        title={patient.villageCode ?? undefined}
+                      />
+                    )}
+                    {formatPatientCode(patient.villageCode, patient.id)}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <PatientPhoto
+                    pictureUrl={patient.patientImageUrl}
+                    className="h-12 w-12 rounded-lg border border-slate-200 object-cover"
+                  />
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm font-medium text-slate-900">
+                    {patient.name}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <button
+                    type="button"
+                    onClick={() => startConsult(patient.id)}
+                    title="Start Consult"
+                    className="inline-flex cursor-pointer items-center gap-2 whitespace-nowrap rounded-lg bg-emerald-600 px-3 py-2 text-sm text-white transition hover:bg-emerald-700"
+                  >
+                    <HiOutlinePencilSquare className="h-5 w-5" />
+                    Start Consult
+                  </button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex-1 p-4">
+      <Breadcrumbs
+        items={[{ label: "Home", href: "/" }, { label: "Consults" }]}
+      />
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-slate-900">Consults</h1>
+        <p className="mt-2 text-slate-600">
+          Select a patient to record a consultation.
+        </p>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        {renderContent()}
+      </div>
+    </div>
+  );
+}
+
+ConsultsPage.getLayout = (page: ReactNode) => withDefaultLayout(page);
+
+export default ConsultsPage;

--- a/src/pages/consults/index.tsx
+++ b/src/pages/consults/index.tsx
@@ -17,7 +17,7 @@ function ConsultsPage() {
     data: patients,
     isLoading,
     isError,
-  } = trpc.patientsRouter.list.useQuery();
+  } = trpc.patientsRouter.listWithLatestVisit.useQuery();
 
   const startConsult = (patientId: number) =>
     router.push(`/consults/${patientId}`);

--- a/src/pages/consults/index.tsx
+++ b/src/pages/consults/index.tsx
@@ -89,7 +89,7 @@ function ConsultsPage() {
   }
 
   return (
-    <div className="min-h-screen flex-1 p-4">
+    <div className="min-h-screen flex-1 p-4 sm:p-6">
       <Breadcrumbs
         items={[{ label: "Home", href: "/" }, { label: "Consults" }]}
       />

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -10,6 +10,7 @@ import { medicationStockRouter } from "./medication_stock_router";
 import { visitsRouter } from "./visits_router";
 import { vitalsRouter } from "./vitals_router";
 import { eyesightRouter } from "./eyesight_router";
+import { consultsRouter } from "./consults_router";
 
 export const appRouter = router({
   healthcheck: publicProcedure.query(() => "yay!"),
@@ -22,6 +23,7 @@ export const appRouter = router({
   visitsRouter: visitsRouter,
   vitalsRouter: vitalsRouter,
   eyesightRouter: eyesightRouter,
+  consultsRouter: consultsRouter,
 });
 
 export const createCaller = createCallerFactory(appRouter);

--- a/src/server/routers/consults_router.ts
+++ b/src/server/routers/consults_router.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, desc, inArray } from "drizzle-orm";
 import { router, protectedProcedure } from "@/server/trpc";
 import { db } from "@/db/drizzle";
 import { consults, diagnosis } from "@/db/schema";
@@ -66,10 +66,24 @@ export const consultsRouter = router({
   getByVisitId: protectedProcedure
     .input(z.object({ visitId: z.number().int().positive() }))
     .query(async ({ input }) => {
-      return db
+      const rows = await db
         .select()
         .from(consults)
-        .where(eq(consults.visitId, input.visitId));
+        .where(eq(consults.visitId, input.visitId))
+        .orderBy(desc(consults.date));
+
+      const ids = rows.map((c) => c.id);
+      const diagnoses = ids.length
+        ? await db
+            .select()
+            .from(diagnosis)
+            .where(inArray(diagnosis.consultId, ids))
+        : [];
+
+      return rows.map((consult) => ({
+        ...consult,
+        diagnoses: diagnoses.filter((d) => d.consultId === consult.id),
+      }));
     }),
 });
 

--- a/src/server/routers/consults_router.ts
+++ b/src/server/routers/consults_router.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { router, protectedProcedure } from "@/server/trpc";
+import { db } from "@/db/drizzle";
+import { consults, diagnosis } from "@/db/schema";
+import { DIAGNOSIS_CATEGORIES } from "@/lib/constants/diagnosisCategories";
+
+/**
+ * Validation schema for a single diagnosis attached to a consult.
+ * Each diagnosis needs free-text details plus a category from the fixed
+ * clinical list.
+ */
+const diagnosisInput = z.object({
+  details: z.string().trim().min(1, "Diagnosis details are required"),
+  category: z.enum(DIAGNOSIS_CATEGORIES),
+});
+
+/**
+ * Input validation schema for creating a consult together with its diagnoses.
+ * `doctorId` is intentionally omitted — it is derived from the authenticated
+ * session, never trusted from the client.
+ */
+const createConsultInput = z.object({
+  visitId: z.number().int().positive(),
+  pastMedicalHistory: z.string().trim().min(1, "Past medical history is required"),
+  consultation: z.string().trim().min(1, "Consultation is required"),
+  treatmentPlan: z.string().optional(),
+  remarks: z.string().optional(),
+  diagnoses: z.array(diagnosisInput),
+});
+
+export const consultsRouter = router({
+  /**
+   * Creates a consult and all of its diagnoses in a single transaction.
+   * If any insert fails, the whole operation rolls back so nothing is
+   * persisted. `doctorId` comes from the authenticated Supabase session.
+   */
+  create: protectedProcedure
+    .input(createConsultInput)
+    .mutation(async ({ input, ctx }) => {
+      const { diagnoses, ...consultData } = input;
+
+      return db.transaction(async (tx) => {
+        const [consult] = await tx
+          .insert(consults)
+          .values({ ...consultData, doctorId: ctx.user.id })
+          .returning();
+
+        if (diagnoses.length > 0) {
+          await tx.insert(diagnosis).values(
+            diagnoses.map((d) => ({
+              details: d.details,
+              category: d.category,
+              consultId: consult.id,
+            })),
+          );
+        }
+
+        return consult;
+      });
+    }),
+
+  /**
+   * Retrieves all consults for a visit, most recent first.
+   */
+  getByVisitId: protectedProcedure
+    .input(z.object({ visitId: z.number().int().positive() }))
+    .query(async ({ input }) => {
+      return db
+        .select()
+        .from(consults)
+        .where(eq(consults.visitId, input.visitId));
+    }),
+});
+
+export type CreateConsultInput = z.infer<typeof createConsultInput>;

--- a/src/server/routers/consults_router.ts
+++ b/src/server/routers/consults_router.ts
@@ -22,7 +22,10 @@ const diagnosisInput = z.object({
  */
 const createConsultInput = z.object({
   visitId: z.number().int().positive(),
-  pastMedicalHistory: z.string().trim().min(1, "Past medical history is required"),
+  pastMedicalHistory: z
+    .string()
+    .trim()
+    .min(1, "Past medical history is required"),
   consultation: z.string().trim().min(1, "Consultation is required"),
   treatmentPlan: z.string().optional(),
   remarks: z.string().optional(),

--- a/src/server/routers/consults_router.ts
+++ b/src/server/routers/consults_router.ts
@@ -24,8 +24,8 @@ const createConsultInput = z.object({
   visitId: z.number().int().positive(),
   pastMedicalHistory: z.string().trim().optional(),
   consultation: z.string().trim().optional(),
-  treatmentPlan: z.string().optional(),
-  remarks: z.string().optional(),
+  treatmentPlan: z.string().trim().optional(),
+  remarks: z.string().trim().optional(),
   diagnoses: z
     .array(diagnosisInput)
     .min(1, "At least one diagnosis is required"),

--- a/src/server/routers/consults_router.ts
+++ b/src/server/routers/consults_router.ts
@@ -29,7 +29,9 @@ const createConsultInput = z.object({
   consultation: z.string().trim().min(1, "Consultation is required"),
   treatmentPlan: z.string().optional(),
   remarks: z.string().optional(),
-  diagnoses: z.array(diagnosisInput),
+  diagnoses: z
+    .array(diagnosisInput)
+    .min(1, "At least one diagnosis is required"),
 });
 
 export const consultsRouter = router({

--- a/src/server/routers/consults_router.ts
+++ b/src/server/routers/consults_router.ts
@@ -22,11 +22,8 @@ const diagnosisInput = z.object({
  */
 const createConsultInput = z.object({
   visitId: z.number().int().positive(),
-  pastMedicalHistory: z
-    .string()
-    .trim()
-    .min(1, "Past medical history is required"),
-  consultation: z.string().trim().min(1, "Consultation is required"),
+  pastMedicalHistory: z.string().trim().optional(),
+  consultation: z.string().trim().optional(),
   treatmentPlan: z.string().optional(),
   remarks: z.string().optional(),
   diagnoses: z


### PR DESCRIPTION
Closes #134 

## Description

Adds the end-to-end consults feature: a doctor picks a patient, selects a visit, reviews that visit's vitals/vision, records a consultation with one or more diagnoses, and sees the visit's prior consults.

## Manual test plan

| No.  | Sequence of Steps | Expected outcome |
|---|---|---|
| 1 | Open Consults → pick a patient | Navigates to `/consults/[patientId]` with breadcrumb + patient id |
| 2 | Patient with **one** visit | Visit auto-selected; vitals panel + consult form render |
| 3 | Patient with **multiple** visits | "Please choose a visit" prompt until one is selected |
| 4 | Submit with required fields empty | Blocked; "Please fill in all required fields" toast; no request sent |
| 5 | Fill valid consult + 1 diagnosis → Save | Success toast; form clears; consult appears under **Previous Consults** |
| 6 | Add several diagnoses, remove some | "Add Diagnosis" appends; Remove disabled when only one remains |
| 7 | Visit with missing vitals | Missing fields show a single `-`; BP with both missing shows `-` (not `- / -`); BMI shows "Invalid/Missing…" |
