### PR TITLE
139 add puberty table to schema

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -268,6 +268,46 @@ export type Eyesight = typeof eyesight.$inferSelect;
 export type NewEyesight = typeof eyesight.$inferInsert;
 
 /*
+Puberty Table:
+- id: Primary key, auto-incrementing integer.
+- pubarche: Whether pubarche has occurred (nullable = not assessed).
+- pubarcheAge: Age at pubarche in years.
+- thelarche: Whether thelarche has occurred.
+- thelarcheAge: Age at thelarche in years.
+- menarche: Whether menarche has occurred.
+- menarcheAge: Age at menarche in years.
+- voiceChange: Whether voice change has occurred.
+- voiceChangeAge: Age at voice change in years.
+- testicularGrowth: Whether testicular growth has occurred.
+- testicularGrowthAge: Age at testicular growth in years.
+- additionalNotes: Additional notes or observations.
+- vitalId: Foreign key referencing the vitals record (unique).
+*/
+export const puberty = pgTable("puberty", {
+  id: serial("id").primaryKey(),
+  pubarche: boolean("pubarche"),
+  pubarcheAge: integer("pubarche_age"),
+  thelarche: boolean("thelarche"),
+  thelarcheAge: integer("thelarche_age"),
+  menarche: boolean("menarche"),
+  menarcheAge: integer("menarche_age"),
+  voiceChange: boolean("voice_change"),
+  voiceChangeAge: integer("voice_change_age"),
+  testicularGrowth: boolean("testicular_growth"),
+  testicularGrowthAge: integer("testicular_growth_age"),
+  additionalNotes: text("additional_notes"),
+  vitalId: integer("vital_id")
+    .notNull()
+    .unique()
+    .references(() => vitals.id, {
+      onDelete: "cascade",
+    }),
+});
+
+export type Puberty = typeof puberty.$inferSelect;
+export type NewPuberty = typeof puberty.$inferInsert;
+
+/*
 Consults Table:
 - id: Primary key, auto-incrementing integer.
 - date: Timestamp of the consultation.

--- a/supabase/migrations/0011_dusty_agent_brand.sql
+++ b/supabase/migrations/0011_dusty_agent_brand.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "puberty" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pubarche" boolean,
+	"pubarche_age" integer,
+	"thelarche" boolean,
+	"thelarche_age" integer,
+	"menarche" boolean,
+	"menarche_age" integer,
+	"voice_change" boolean,
+	"voice_change_age" integer,
+	"testicular_growth" boolean,
+	"testicular_growth_age" integer,
+	"additional_notes" text,
+	"vital_id" integer NOT NULL,
+	CONSTRAINT "puberty_vital_id_unique" UNIQUE("vital_id")
+);
+--> statement-breakpoint
+ALTER TABLE "puberty" ADD CONSTRAINT "puberty_vital_id_vitals_id_fk" FOREIGN KEY ("vital_id") REFERENCES "public"."vitals"("id") ON DELETE cascade ON UPDATE no action;

--- a/supabase/migrations/meta/0011_snapshot.json
+++ b/supabase/migrations/meta/0011_snapshot.json
@@ -1,0 +1,902 @@
+{
+  "id": "211e12dd-c4fd-4d3b-b951-ee6c5f9fcc40",
+  "prevId": "8e436c93-668e-4adc-97fd-1a785809bb6d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consults": {
+      "name": "consults",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "past_medical_history": {
+          "name": "past_medical_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consultation": {
+          "name": "consultation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "treatment_plan": {
+          "name": "treatment_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consults_doctor_id_users_id_fk": {
+          "name": "consults_doctor_id_users_id_fk",
+          "tableFrom": "consults",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consults_visit_id_visits_id_fk": {
+          "name": "consults_visit_id_visits_id_fk",
+          "tableFrom": "consults",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diagnosis": {
+      "name": "diagnosis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consult_id": {
+          "name": "consult_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "diagnosis_consult_id_consults_id_fk": {
+          "name": "diagnosis_consult_id_consults_id_fk",
+          "tableFrom": "diagnosis",
+          "tableTo": "consults",
+          "columnsFrom": [
+            "consult_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eyesight": {
+      "name": "eyesight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "left_eye_degree": {
+          "name": "left_eye_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_eye_degree": {
+          "name": "right_eye_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_eye_pinhole": {
+          "name": "left_eye_pinhole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_eye_pinhole": {
+          "name": "right_eye_pinhole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_astigmatism": {
+          "name": "left_astigmatism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_astigmatism": {
+          "name": "right_astigmatism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_prescribed_glasses_degree": {
+          "name": "left_prescribed_glasses_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_prescribed_glasses_degree": {
+          "name": "right_prescribed_glasses_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "eyesight_visit_id_visits_id_fk": {
+          "name": "eyesight_visit_id_visits_id_fk",
+          "tableFrom": "eyesight",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "eyesight_visit_id_unique": {
+          "name": "eyesight_visit_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_active_ingredients": {
+      "name": "medication_active_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measurement": {
+          "name": "unit_of_measurement",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fall_below": {
+          "name": "fall_below",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_brands": {
+      "name": "medication_brands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_ingredient_id": {
+          "name": "active_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_brands_active_ingredient_id_medication_active_ingredients_id_fk": {
+          "name": "medication_brands_active_ingredient_id_medication_active_ingredients_id_fk",
+          "tableFrom": "medication_brands",
+          "tableTo": "medication_active_ingredients",
+          "columnsFrom": [
+            "active_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_stock": {
+      "name": "medication_stock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_brand_id": {
+          "name": "medication_brand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_status": {
+          "name": "stock_status",
+          "type": "medication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_stock_medication_brand_id_medication_brands_id_fk": {
+          "name": "medication_stock_medication_brand_id_medication_brands_id_fk",
+          "tableFrom": "medication_stock",
+          "tableTo": "medication_brands",
+          "columnsFrom": [
+            "medication_brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_no": {
+          "name": "contact_no",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_allergy": {
+          "name": "drug_allergy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_poor_card": {
+          "name": "has_poor_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_bs2_card": {
+          "name": "has_bs2_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_sabai_card": {
+          "name": "has_sabai_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_image_public_id": {
+          "name": "patient_image_public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rekognition_face_id": {
+          "name": "rekognition_face_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.puberty": {
+      "name": "puberty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pubarche": {
+          "name": "pubarche",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pubarche_age": {
+          "name": "pubarche_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thelarche": {
+          "name": "thelarche",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thelarche_age": {
+          "name": "thelarche_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menarche": {
+          "name": "menarche",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menarche_age": {
+          "name": "menarche_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_change": {
+          "name": "voice_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_change_age": {
+          "name": "voice_change_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "testicular_growth": {
+          "name": "testicular_growth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "testicular_growth_age": {
+          "name": "testicular_growth_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_notes": {
+          "name": "additional_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_id": {
+          "name": "vital_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "puberty_vital_id_vitals_id_fk": {
+          "name": "puberty_vital_id_vitals_id_fk",
+          "tableFrom": "puberty",
+          "tableTo": "vitals",
+          "columnsFrom": [
+            "vital_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "puberty_vital_id_unique": {
+          "name": "puberty_vital_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "vital_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.village_codes": {
+      "name": "village_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "village_codes_code_unique": {
+          "name": "village_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visits": {
+      "name": "visits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "village_code_id": {
+          "name": "village_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "visits_patient_id_patients_id_fk": {
+          "name": "visits_patient_id_patients_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visits_village_code_id_village_codes_id_fk": {
+          "name": "visits_village_code_id_village_codes_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "village_codes",
+          "columnsFrom": [
+            "village_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vitals": {
+      "name": "vitals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hemocue_count": {
+          "name": "hemocue_count",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diabetes_mellitus": {
+          "name": "diabetes_mellitus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urine_test": {
+          "name": "urine_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_glucose_non_fasting": {
+          "name": "blood_glucose_non_fasting",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_glucose_fasting": {
+          "name": "blood_glucose_fasting",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hba1c": {
+          "name": "hba1c",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "others": {
+          "name": "others",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vitals_visit_id_visits_id_fk": {
+          "name": "vitals_visit_id_visits_id_fk",
+          "tableFrom": "vitals",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vitals_visit_id_unique": {
+          "name": "vitals_visit_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.medication_status": {
+      "name": "medication_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disposed",
+        "donated",
+        "expired"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1783249778562,
       "tag": "0010_violet_zuras",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1783836783254,
+      "tag": "0011_dusty_agent_brand",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #139 

## Description

- Adds the puberty child-vitals table at the data layer

## Additional Notes
- dropped `grade_id` temporarily — not part of this issue's AC.

## Out of scope (follow-ups from this PR)

- tRPC router / Zod validation for puberty CRUD operations
- Age-based conditional display in the UI vitals