### PR TITLE
140 add routers for puberty fields

### DIFF
--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -10,7 +10,7 @@ import { medicationStockRouter } from "./medication_stock_router";
 import { visitsRouter } from "./visits_router";
 import { vitalsRouter } from "./vitals_router";
 import { eyesightRouter } from "./eyesight_router";
-import { consultsRouter } from "./consults_router";
+import { pubertyRouter } from "./puberty_router";
 
 export const appRouter = router({
   healthcheck: publicProcedure.query(() => "yay!"),
@@ -23,7 +23,7 @@ export const appRouter = router({
   visitsRouter: visitsRouter,
   vitalsRouter: vitalsRouter,
   eyesightRouter: eyesightRouter,
-  consultsRouter: consultsRouter,
+  pubertyRouter: pubertyRouter,
 });
 
 export const createCaller = createCallerFactory(appRouter);

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -11,6 +11,7 @@ import { visitsRouter } from "./visits_router";
 import { vitalsRouter } from "./vitals_router";
 import { eyesightRouter } from "./eyesight_router";
 import { pubertyRouter } from "./puberty_router";
+import { consultsRouter } from "./consults_router";
 
 export const appRouter = router({
   healthcheck: publicProcedure.query(() => "yay!"),
@@ -24,6 +25,7 @@ export const appRouter = router({
   vitalsRouter: vitalsRouter,
   eyesightRouter: eyesightRouter,
   pubertyRouter: pubertyRouter,
+  consultsRouter: consultsRouter,
 });
 
 export const createCaller = createCallerFactory(appRouter);

--- a/src/server/routers/puberty_router.ts
+++ b/src/server/routers/puberty_router.ts
@@ -24,8 +24,6 @@ const selectPubertyFields = {
   vitalId: puberty.vitalId,
 };
 
-const MAX_PUBERTY_AGE = 18;
-
 const pubertyAgePairs = [
   { flag: "pubarche", age: "pubarcheAge" },
   { flag: "thelarche", age: "thelarcheAge" },
@@ -53,20 +51,15 @@ function validatePubertyAges(
 // because ZodEffects (returned by superRefine) does not support .omit()/.partial().
 const pubertyBaseShape = z.object({
   pubarche: z.boolean().optional(),
-  pubarcheAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
+  pubarcheAge: z.number().int().positive().optional(),
   thelarche: z.boolean().optional(),
-  thelarcheAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
+  thelarcheAge: z.number().int().positive().optional(),
   menarche: z.boolean().optional(),
-  menarcheAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
+  menarcheAge: z.number().int().positive().optional(),
   voiceChange: z.boolean().optional(),
-  voiceChangeAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
+  voiceChangeAge: z.number().int().positive().optional(),
   testicularGrowth: z.boolean().optional(),
-  testicularGrowthAge: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_PUBERTY_AGE)
-    .optional(),
+  testicularGrowthAge: z.number().int().positive().optional(),
   additionalNotes: z.string().optional(),
   vitalId: z.number().int().positive(),
 });

--- a/src/server/routers/puberty_router.ts
+++ b/src/server/routers/puberty_router.ts
@@ -9,67 +9,70 @@ import { puberty } from "@/db/schema";
  * and reduce code duplication across different procedures.
  */
 const selectPubertyFields = {
-    id: puberty.id,
-    pubarche: puberty.pubarche,
-    pubarcheAge: puberty.pubarcheAge,
-    thelarche: puberty.thelarche,
-    thelarcheAge: puberty.thelarcheAge,
-    menarche: puberty.menarche,
-    menarcheAge: puberty.menarcheAge,
-    voiceChange: puberty.voiceChange,
-    voiceChangeAge: puberty.voiceChangeAge,
-    testicularGrowth: puberty.testicularGrowth,
-    testicularGrowthAge: puberty.testicularGrowthAge,
-    additionalNotes: puberty.additionalNotes,
-    vitalId: puberty.vitalId,
-}
+  id: puberty.id,
+  pubarche: puberty.pubarche,
+  pubarcheAge: puberty.pubarcheAge,
+  thelarche: puberty.thelarche,
+  thelarcheAge: puberty.thelarcheAge,
+  menarche: puberty.menarche,
+  menarcheAge: puberty.menarcheAge,
+  voiceChange: puberty.voiceChange,
+  voiceChangeAge: puberty.voiceChangeAge,
+  testicularGrowth: puberty.testicularGrowth,
+  testicularGrowthAge: puberty.testicularGrowthAge,
+  additionalNotes: puberty.additionalNotes,
+  vitalId: puberty.vitalId,
+};
 
 /**
  * Input validation schema for creating puberty records.
  */
 const createPubertyInput = z.object({
-    pubarche: z.boolean().optional(),
-    pubarcheAge: z.number().int().optional(),
-    thelarche: z.boolean().optional(),
-    thelarcheAge: z.number().int().optional(),
-    menarche: z.boolean().optional(),
-    menarcheAge: z.number().int().optional(),
-    voiceChange: z.boolean().optional(),
-    voiceChangeAge: z.number().int().optional(),
-    testicularGrowth: z.boolean().optional(),
-    testicularGrowthAge: z.number().int().optional(),
-    additionalNotes: z.string().optional(),
-    vitalId: z.number().int().positive(),
+  pubarche: z.boolean().optional(),
+  pubarcheAge: z.number().int().positive().optional(),
+  thelarche: z.boolean().optional(),
+  thelarcheAge: z.number().int().positive().optional(),
+  menarche: z.boolean().optional(),
+  menarcheAge: z.number().int().positive().optional(),
+  voiceChange: z.boolean().optional(),
+  voiceChangeAge: z.number().int().positive().optional(),
+  testicularGrowth: z.boolean().optional(),
+  testicularGrowthAge: z.number().int().positive().optional(),
+  additionalNotes: z.string().optional(),
+  vitalId: z.number().int().positive(),
 });
 
 /**
  * Input validation schema for updating puberty records.
  */
 const updatePubertyInput = createPubertyInput
-    .omit({vitalId: true})
-    .partial()
-    .extend({
-        id: z.number().int().positive(),
-    });
+  .omit({ vitalId: true })
+  .partial()
+  .extend({
+    id: z.number().int().positive(),
+  });
 
 /**
  * Input validation schema for updating puberty records by vitalsId.
- */  
+ */
 const updatePubertyInputByVitalsId = createPubertyInput
-    .omit({vitalId:true}) //we want it to always be attached to the same vital object
-    .partial()
-    .extend({
-        vitalId: z.number().int().positive()
-    });
+  .omit({ vitalId: true }) //we want it to always be attached to the same vital object
+  .partial()
+  .extend({
+    vitalId: z.number().int().positive(),
+  });
 
-    export const pubertyRouter = router({
+export const pubertyRouter = router({
   /**
    * Creates a new puberty record for a vitals record.
    */
   create: protectedProcedure
     .input(createPubertyInput)
     .mutation(async ({ input }) => {
-      const [pubertyRecord] = await db.insert(puberty).values(input).returning();
+      const [pubertyRecord] = await db
+        .insert(puberty)
+        .values(input)
+        .returning();
       return pubertyRecord;
     }),
 

--- a/src/server/routers/puberty_router.ts
+++ b/src/server/routers/puberty_router.ts
@@ -56,7 +56,7 @@ const updatePubertyInput = createPubertyInput
  * Input validation schema for updating puberty records by vitalsId.
  */
 const updatePubertyInputByVitalsId = createPubertyInput
-  .omit({ vitalId: true }) //we want it to always be attached to the same vital object
+  .omit({ vitalId: true }) // We want it to always be attached to the same vital object
   .partial()
   .extend({
     vitalId: z.number().int().positive(),

--- a/src/server/routers/puberty_router.ts
+++ b/src/server/routers/puberty_router.ts
@@ -24,43 +24,79 @@ const selectPubertyFields = {
   vitalId: puberty.vitalId,
 };
 
-/**
- * Input validation schema for creating puberty records.
- */
-const createPubertyInput = z.object({
+const MAX_PUBERTY_AGE = 18;
+
+const pubertyAgePairs = [
+  { flag: "pubarche", age: "pubarcheAge" },
+  { flag: "thelarche", age: "thelarcheAge" },
+  { flag: "menarche", age: "menarcheAge" },
+  { flag: "voiceChange", age: "voiceChangeAge" },
+  { flag: "testicularGrowth", age: "testicularGrowthAge" },
+] as const;
+
+function validatePubertyAges(
+  data: Record<string, unknown>,
+  ctx: z.RefinementCtx,
+) {
+  for (const { flag, age } of pubertyAgePairs) {
+    if (data[flag] === false && data[age] !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${age} must not be set when ${flag} is false`,
+        path: [age],
+      });
+    }
+  }
+}
+
+// Base object used for schema derivation — superRefine is applied per schema below
+// because ZodEffects (returned by superRefine) does not support .omit()/.partial().
+const pubertyBaseShape = z.object({
   pubarche: z.boolean().optional(),
-  pubarcheAge: z.number().int().positive().optional(),
+  pubarcheAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
   thelarche: z.boolean().optional(),
-  thelarcheAge: z.number().int().positive().optional(),
+  thelarcheAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
   menarche: z.boolean().optional(),
-  menarcheAge: z.number().int().positive().optional(),
+  menarcheAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
   voiceChange: z.boolean().optional(),
-  voiceChangeAge: z.number().int().positive().optional(),
+  voiceChangeAge: z.number().int().positive().max(MAX_PUBERTY_AGE).optional(),
   testicularGrowth: z.boolean().optional(),
-  testicularGrowthAge: z.number().int().positive().optional(),
+  testicularGrowthAge: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_PUBERTY_AGE)
+    .optional(),
   additionalNotes: z.string().optional(),
   vitalId: z.number().int().positive(),
 });
 
 /**
+ * Input validation schema for creating puberty records.
+ */
+const createPubertyInput = pubertyBaseShape.superRefine(validatePubertyAges);
+
+/**
  * Input validation schema for updating puberty records.
  */
-const updatePubertyInput = createPubertyInput
+const updatePubertyInput = pubertyBaseShape
   .omit({ vitalId: true })
   .partial()
   .extend({
     id: z.number().int().positive(),
-  });
+  })
+  .superRefine(validatePubertyAges);
 
 /**
  * Input validation schema for updating puberty records by vitalsId.
  */
-const updatePubertyInputByVitalsId = createPubertyInput
+const updatePubertyInputByVitalsId = pubertyBaseShape
   .omit({ vitalId: true }) // We want it to always be attached to the same vital object
   .partial()
   .extend({
     vitalId: z.number().int().positive(),
-  });
+  })
+  .superRefine(validatePubertyAges);
 
 export const pubertyRouter = router({
   /**
@@ -72,7 +108,7 @@ export const pubertyRouter = router({
       const [pubertyRecord] = await db
         .insert(puberty)
         .values(input)
-        .returning();
+        .returning(selectPubertyFields);
       return pubertyRecord;
     }),
 
@@ -121,7 +157,7 @@ export const pubertyRouter = router({
         .where(eq(puberty.id, id))
         .returning();
 
-      return updatedPuberty;
+      return updatedPuberty ?? null;
     }),
 
   /**
@@ -139,7 +175,7 @@ export const pubertyRouter = router({
         .where(eq(puberty.vitalId, vitalId))
         .returning();
 
-      return updatedPuberty;
+      return updatedPuberty ?? null;
     }),
 
   /**

--- a/src/server/routers/puberty_router.ts
+++ b/src/server/routers/puberty_router.ts
@@ -41,7 +41,7 @@ function validatePubertyAges(
   for (const { flag, age } of pubertyAgePairs) {
     if (data[flag] === false && data[age] !== undefined) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message: `${age} must not be set when ${flag} is false`,
         path: [age],
       });

--- a/src/server/routers/puberty_router.ts
+++ b/src/server/routers/puberty_router.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { router, protectedProcedure } from "@/server/trpc";
+import { db } from "@/db/drizzle";
+import { puberty } from "@/db/schema";
+
+/**
+ * Common select fields for puberty queries to ensure consistency
+ * and reduce code duplication across different procedures.
+ */
+const selectPubertyFields = {
+    id: puberty.id,
+    pubarche: puberty.pubarche,
+    pubarcheAge: puberty.pubarcheAge,
+    thelarche: puberty.thelarche,
+    thelarcheAge: puberty.thelarcheAge,
+    menarche: puberty.menarche,
+    menarcheAge: puberty.menarcheAge,
+    voiceChange: puberty.voiceChange,
+    voiceChangeAge: puberty.voiceChangeAge,
+    testicularGrowth: puberty.testicularGrowth,
+    testicularGrowthAge: puberty.testicularGrowthAge,
+    additionalNotes: puberty.additionalNotes,
+    vitalId: puberty.vitalId,
+}
+
+/**
+ * Input validation schema for creating puberty records.
+ */
+const createPubertyInput = z.object({
+    pubarche: z.boolean().optional(),
+    pubarcheAge: z.number().int().optional(),
+    thelarche: z.boolean().optional(),
+    thelarcheAge: z.number().int().optional(),
+    menarche: z.boolean().optional(),
+    menarcheAge: z.number().int().optional(),
+    voiceChange: z.boolean().optional(),
+    voiceChangeAge: z.number().int().optional(),
+    testicularGrowth: z.boolean().optional(),
+    testicularGrowthAge: z.number().int().optional(),
+    additionalNotes: z.string().optional(),
+    vitalId: z.number().int().positive(),
+});
+
+/**
+ * Input validation schema for updating puberty records.
+ */
+const updatePubertyInput = createPubertyInput
+    .omit({vitalId: true})
+    .partial()
+    .extend({
+        id: z.number().int().positive(),
+    });
+
+/**
+ * Input validation schema for updating puberty records by vitalsId.
+ */  
+const updatePubertyInputByVitalsId = createPubertyInput
+    .omit({vitalId:true}) //we want it to always be attached to the same vital object
+    .partial()
+    .extend({
+        vitalId: z.number().int().positive()
+    });
+
+    export const pubertyRouter = router({
+  /**
+   * Creates a new puberty record for a vitals record.
+   */
+  create: protectedProcedure
+    .input(createPubertyInput)
+    .mutation(async ({ input }) => {
+      const [pubertyRecord] = await db.insert(puberty).values(input).returning();
+      return pubertyRecord;
+    }),
+
+  /**
+   * Retrieves a puberty record by its primary ID.
+   */
+  getById: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .query(async ({ input }) => {
+      const pubertyRecord = await db
+        .select(selectPubertyFields)
+        .from(puberty)
+        .where(eq(puberty.id, input.id))
+        .limit(1);
+
+      return pubertyRecord[0] ?? null;
+    }),
+
+  /**
+   * Retrieves a puberty record by its vital ID.
+   */
+  getByVitalId: protectedProcedure
+    .input(z.object({ vitalId: z.number().int().positive() }))
+    .query(async ({ input }) => {
+      const pubertyRecord = await db
+        .select(selectPubertyFields)
+        .from(puberty)
+        .where(eq(puberty.vitalId, input.vitalId))
+        .limit(1);
+
+      return pubertyRecord[0] ?? null;
+    }),
+
+  /**
+   * Updates a puberty record by its primary ID.
+   * Only updates provided fields (partial update).
+   */
+  update: protectedProcedure
+    .input(updatePubertyInput)
+    .mutation(async ({ input }) => {
+      const { id, ...updateData } = input;
+
+      const [updatedPuberty] = await db
+        .update(puberty)
+        .set(updateData)
+        .where(eq(puberty.id, id))
+        .returning();
+
+      return updatedPuberty;
+    }),
+
+  /**
+   * Updates a puberty record by vital ID.
+   * Only updates provided fields (partial update).
+   */
+  updateByVitalId: protectedProcedure
+    .input(updatePubertyInputByVitalsId)
+    .mutation(async ({ input }) => {
+      const { vitalId, ...updateData } = input;
+
+      const [updatedPuberty] = await db
+        .update(puberty)
+        .set(updateData)
+        .where(eq(puberty.vitalId, vitalId))
+        .returning();
+
+      return updatedPuberty;
+    }),
+
+  /**
+   * Deletes a puberty record by its primary ID.
+   */
+  delete: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .mutation(async ({ input }) => {
+      await db.delete(puberty).where(eq(puberty.id, input.id));
+      return { success: true };
+    }),
+});
+
+// Export types for use in other parts of the application
+export type CreatePubertyInput = z.infer<typeof createPubertyInput>;
+export type UpdatePubertyInput = z.infer<typeof updatePubertyInput>;
+export type UpdatePubertyInputByVitalsId = z.infer<
+  typeof updatePubertyInputByVitalsId
+>;


### PR DESCRIPTION
Closes #140

## Description

* Adds the tRPC router endpoints (`create`, `getById`, `getByVitalId`, `update`, `updateByVitalId`, `delete`) to read and write puberty records.
* Implements runtime input validation schemas using Zod (`createPubertyInput`, `updatePubertyInput`, `updatePubertyInputByVitalsId`) to enforce type-safe data handling.
* Links the new `pubertyRouter` into the primary app router configuration (`_app.ts`).

## Additional Notes

* All puberty development metrics and assessment inputs are configured as optional properties to accommodate incomplete or unassessed records.
* Exported inferred TypeScript data and input validation shapes to preserve type safety across the application boundaries.

## Out of scope (follow-ups from this PR)

* Integration of the puberty metrics section into the frontend user interface.
* Implementing age-based conditional display logic within the UI vitals view.