### PR TITLE
Fix unintended code change when merging branches

### DIFF
--- a/src/components/scanFace/MatchingPatients.tsx
+++ b/src/components/scanFace/MatchingPatients.tsx
@@ -18,7 +18,7 @@ export default function MatchingPatients({
   const searchPatientsByPictureQuery =
     trpc.patientsRouter.searchPatientsByPicture.useMutation();
   useEffect(() => {
-    findFaceMatchMutation.mutate({ picture: imgDetails! });
+    searchPatientsByPictureQuery.mutate({ picture: imgDetails });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imgDetails]); // suppress warning about missing dependencies because we only want to run this effect when imgDetails changes
 


### PR DESCRIPTION
Changed a `useEffect` function to use an old query while resolving merge conflicts. Need to change it to use the currently existing query if not the build will fail