### PR TITLE
37 referral schemas

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -363,12 +363,12 @@ export type NewDiagnosis = typeof diagnosis.$inferInsert;
 /*
 Referrals Table:
 - id: Primary key, auto-incrementing integer.
-- referredFor: The reason/specialty the patient is referred for (the "why").
-- referredTo: The destination the patient is referred to, e.g. hospital/department/provider (the "where").
-- referralNotes: Free-text notes about the referral.
+- referredFor: The reason that the patient is referred for.
+- referredTo: The destination clinic that the patient is referred to
+- referralNotes: Free-text notes about the referral notes
 - referralState: Lifecycle state of the referral (e.g. 'pending', 'completed', 'cancelled').
-- referralOutcome: Free-text result of the referral.
-- consultId: Foreign key referencing the consult. Referral cannot be deleted out from under a consult (restrict).
+- referralOutcome: Free-text result of the referral outcome
+- consultId: Foreign key referencing the consult. Referral cannot be deleted out from under a consult (restrict). Deleting a consult that still have referrals should be blocked
 - createdAt: Timestamp of when the referral was created.
 */
 export const referrals = pgTable("referrals", {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,6 +26,11 @@ export const medicationStatusEnum = pgEnum("medication_status", [
   "donated",
   "expired",
 ]);
+export const referralStateEnum = pgEnum("referral_state", [
+  "pending",
+  "completed",
+  "cancelled",
+]);
 
 // Define tables
 
@@ -354,6 +359,35 @@ export const diagnosis = pgTable("diagnosis", {
 
 export type Diagnosis = typeof diagnosis.$inferSelect;
 export type NewDiagnosis = typeof diagnosis.$inferInsert;
+
+/*
+Referrals Table:
+- id: Primary key, auto-incrementing integer.
+- referredFor: The reason/specialty the patient is referred for (the "why").
+- referredTo: The destination the patient is referred to, e.g. hospital/department/provider (the "where").
+- referralNotes: Free-text notes about the referral.
+- referralState: Lifecycle state of the referral (e.g. 'pending', 'completed', 'cancelled').
+- referralOutcome: Free-text result of the referral.
+- consultId: Foreign key referencing the consult. Referral cannot be deleted out from under a consult (restrict).
+- createdAt: Timestamp of when the referral was created.
+*/
+export const referrals = pgTable("referrals", {
+  id: serial("id").primaryKey(),
+  referredFor: text("referred_for").notNull(),
+  referredTo: text("referred_to"),
+  referralNotes: text("referral_notes"),
+  referralState: referralStateEnum("referral_state").default("pending"),
+  referralOutcome: text("referral_outcome"),
+  consultId: integer("consult_id")
+    .notNull()
+    .references(() => consults.id, {
+      onDelete: "restrict",
+    }),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export type Referral = typeof referrals.$inferSelect;
+export type NewReferral = typeof referrals.$inferInsert;
 
 // todo: medication_log table (after users table done)
 // todo: medication_review table (after users table done)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -27,9 +27,13 @@ export const medicationStatusEnum = pgEnum("medication_status", [
   "expired",
 ]);
 export const referralStateEnum = pgEnum("referral_state", [
-  "pending",
-  "completed",
-  "cancelled",
+  "CompletedFailure",
+  "New",
+  "Seen",
+  "Outgoing",
+  "CompletedSuccess",
+  "Completed",
+  "None",
 ]);
 
 // Define tables
@@ -363,20 +367,18 @@ export type NewDiagnosis = typeof diagnosis.$inferInsert;
 /*
 Referrals Table:
 - id: Primary key, auto-incrementing integer.
-- referredFor: The reason that the patient is referred for.
-- referredTo: The destination clinic that the patient is referred to
-- referralNotes: Free-text notes about the referral notes
-- referralState: Lifecycle state of the referral (e.g. 'pending', 'completed', 'cancelled').
-- referralOutcome: Free-text result of the referral outcome
-- consultId: Foreign key referencing the consult. Referral cannot be deleted out from under a consult (restrict). Deleting a consult that still have referrals should be blocked
+- referredFor: The reason the patient is referred.
+- referralNotes: Free-text notes about the referral.
+- referralState: Lifecycle state of the referral (e.g. 'New', 'Completed').
+- referralOutcome: Free-text result of the referral.
+- consultId: Foreign key referencing the consult. Deleting a consult that still has referrals is blocked (restrict).
 - createdAt: Timestamp of when the referral was created.
 */
 export const referrals = pgTable("referrals", {
   id: serial("id").primaryKey(),
   referredFor: text("referred_for").notNull(),
-  referredTo: text("referred_to"),
   referralNotes: text("referral_notes"),
-  referralState: referralStateEnum("referral_state").default("pending"),
+  referralState: referralStateEnum("referral_state").default("New").notNull(),
   referralOutcome: text("referral_outcome"),
   consultId: integer("consult_id")
     .notNull()

--- a/supabase/migrations/0012_slimy_arclight.sql
+++ b/supabase/migrations/0012_slimy_arclight.sql
@@ -1,0 +1,13 @@
+CREATE TYPE "public"."referral_state" AS ENUM('pending', 'completed', 'cancelled');--> statement-breakpoint
+CREATE TABLE "referrals" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"referred_for" text NOT NULL,
+	"referred_to" text,
+	"referral_notes" text,
+	"referral_state" "referral_state" DEFAULT 'pending',
+	"referral_outcome" text,
+	"consult_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "referrals" ADD CONSTRAINT "referrals_consult_id_consults_id_fk" FOREIGN KEY ("consult_id") REFERENCES "public"."consults"("id") ON DELETE restrict ON UPDATE no action;

--- a/supabase/migrations/0012_slimy_arclight.sql
+++ b/supabase/migrations/0012_slimy_arclight.sql
@@ -1,10 +1,9 @@
-CREATE TYPE "public"."referral_state" AS ENUM('pending', 'completed', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."referral_state" AS ENUM('CompletedFailure', 'New', 'Seen', 'Outgoing', 'CompletedSuccess', 'Completed', 'None');--> statement-breakpoint
 CREATE TABLE "referrals" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"referred_for" text NOT NULL,
-	"referred_to" text,
 	"referral_notes" text,
-	"referral_state" "referral_state" DEFAULT 'pending',
+	"referral_state" "referral_state" DEFAULT 'New' NOT NULL,
 	"referral_outcome" text,
 	"consult_id" integer NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL

--- a/supabase/migrations/meta/0012_snapshot.json
+++ b/supabase/migrations/meta/0012_snapshot.json
@@ -628,12 +628,6 @@
           "primaryKey": false,
           "notNull": true
         },
-        "referred_to": {
-          "name": "referred_to",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "referral_notes": {
           "name": "referral_notes",
           "type": "text",
@@ -645,8 +639,8 @@
           "type": "referral_state",
           "typeSchema": "public",
           "primaryKey": false,
-          "notNull": false,
-          "default": "'pending'"
+          "notNull": true,
+          "default": "'New'"
         },
         "referral_outcome": {
           "name": "referral_outcome",
@@ -970,9 +964,13 @@
       "name": "referral_state",
       "schema": "public",
       "values": [
-        "pending",
-        "completed",
-        "cancelled"
+        "CompletedFailure",
+        "New",
+        "Seen",
+        "Outgoing",
+        "CompletedSuccess",
+        "Completed",
+        "None"
       ]
     }
   },

--- a/supabase/migrations/meta/0012_snapshot.json
+++ b/supabase/migrations/meta/0012_snapshot.json
@@ -1,0 +1,989 @@
+{
+  "id": "1e706ff7-9f28-4c81-ac9e-b8bdea5d326e",
+  "prevId": "211e12dd-c4fd-4d3b-b951-ee6c5f9fcc40",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consults": {
+      "name": "consults",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "past_medical_history": {
+          "name": "past_medical_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consultation": {
+          "name": "consultation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "treatment_plan": {
+          "name": "treatment_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consults_doctor_id_users_id_fk": {
+          "name": "consults_doctor_id_users_id_fk",
+          "tableFrom": "consults",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consults_visit_id_visits_id_fk": {
+          "name": "consults_visit_id_visits_id_fk",
+          "tableFrom": "consults",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diagnosis": {
+      "name": "diagnosis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consult_id": {
+          "name": "consult_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "diagnosis_consult_id_consults_id_fk": {
+          "name": "diagnosis_consult_id_consults_id_fk",
+          "tableFrom": "diagnosis",
+          "tableTo": "consults",
+          "columnsFrom": [
+            "consult_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eyesight": {
+      "name": "eyesight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "left_eye_degree": {
+          "name": "left_eye_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_eye_degree": {
+          "name": "right_eye_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_eye_pinhole": {
+          "name": "left_eye_pinhole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_eye_pinhole": {
+          "name": "right_eye_pinhole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_astigmatism": {
+          "name": "left_astigmatism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_astigmatism": {
+          "name": "right_astigmatism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_prescribed_glasses_degree": {
+          "name": "left_prescribed_glasses_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "right_prescribed_glasses_degree": {
+          "name": "right_prescribed_glasses_degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "eyesight_visit_id_visits_id_fk": {
+          "name": "eyesight_visit_id_visits_id_fk",
+          "tableFrom": "eyesight",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "eyesight_visit_id_unique": {
+          "name": "eyesight_visit_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_active_ingredients": {
+      "name": "medication_active_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measurement": {
+          "name": "unit_of_measurement",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fall_below": {
+          "name": "fall_below",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_brands": {
+      "name": "medication_brands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_ingredient_id": {
+          "name": "active_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_brands_active_ingredient_id_medication_active_ingredients_id_fk": {
+          "name": "medication_brands_active_ingredient_id_medication_active_ingredients_id_fk",
+          "tableFrom": "medication_brands",
+          "tableTo": "medication_active_ingredients",
+          "columnsFrom": [
+            "active_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_stock": {
+      "name": "medication_stock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_brand_id": {
+          "name": "medication_brand_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_status": {
+          "name": "stock_status",
+          "type": "medication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_stock_medication_brand_id_medication_brands_id_fk": {
+          "name": "medication_stock_medication_brand_id_medication_brands_id_fk",
+          "tableFrom": "medication_stock",
+          "tableTo": "medication_brands",
+          "columnsFrom": [
+            "medication_brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_no": {
+          "name": "contact_no",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_allergy": {
+          "name": "drug_allergy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_poor_card": {
+          "name": "has_poor_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_bs2_card": {
+          "name": "has_bs2_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_sabai_card": {
+          "name": "has_sabai_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_image_public_id": {
+          "name": "patient_image_public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rekognition_face_id": {
+          "name": "rekognition_face_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.puberty": {
+      "name": "puberty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pubarche": {
+          "name": "pubarche",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pubarche_age": {
+          "name": "pubarche_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thelarche": {
+          "name": "thelarche",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thelarche_age": {
+          "name": "thelarche_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menarche": {
+          "name": "menarche",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menarche_age": {
+          "name": "menarche_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_change": {
+          "name": "voice_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_change_age": {
+          "name": "voice_change_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "testicular_growth": {
+          "name": "testicular_growth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "testicular_growth_age": {
+          "name": "testicular_growth_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_notes": {
+          "name": "additional_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_id": {
+          "name": "vital_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "puberty_vital_id_vitals_id_fk": {
+          "name": "puberty_vital_id_vitals_id_fk",
+          "tableFrom": "puberty",
+          "tableTo": "vitals",
+          "columnsFrom": [
+            "vital_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "puberty_vital_id_unique": {
+          "name": "puberty_vital_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "vital_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referrals": {
+      "name": "referrals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "referred_for": {
+          "name": "referred_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referred_to": {
+          "name": "referred_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_notes": {
+          "name": "referral_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_state": {
+          "name": "referral_state",
+          "type": "referral_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "referral_outcome": {
+          "name": "referral_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consult_id": {
+          "name": "consult_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "referrals_consult_id_consults_id_fk": {
+          "name": "referrals_consult_id_consults_id_fk",
+          "tableFrom": "referrals",
+          "tableTo": "consults",
+          "columnsFrom": [
+            "consult_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.village_codes": {
+      "name": "village_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "village_codes_code_unique": {
+          "name": "village_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visits": {
+      "name": "visits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "village_code_id": {
+          "name": "village_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "visits_patient_id_patients_id_fk": {
+          "name": "visits_patient_id_patients_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visits_village_code_id_village_codes_id_fk": {
+          "name": "visits_village_code_id_village_codes_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "village_codes",
+          "columnsFrom": [
+            "village_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vitals": {
+      "name": "vitals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hemocue_count": {
+          "name": "hemocue_count",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diabetes_mellitus": {
+          "name": "diabetes_mellitus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urine_test": {
+          "name": "urine_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_glucose_non_fasting": {
+          "name": "blood_glucose_non_fasting",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_glucose_fasting": {
+          "name": "blood_glucose_fasting",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hba1c": {
+          "name": "hba1c",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "others": {
+          "name": "others",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vitals_visit_id_visits_id_fk": {
+          "name": "vitals_visit_id_visits_id_fk",
+          "tableFrom": "vitals",
+          "tableTo": "visits",
+          "columnsFrom": [
+            "visit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vitals_visit_id_unique": {
+          "name": "vitals_visit_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "visit_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.medication_status": {
+      "name": "medication_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disposed",
+        "donated",
+        "expired"
+      ]
+    },
+    "public.referral_state": {
+      "name": "referral_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1783836783254,
       "tag": "0011_dusty_agent_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1784724949701,
+      "tag": "0012_slimy_arclight",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #37

## Description
- Adds a `referrals` table to the Drizzle schema

## Fields added
| Field | Type | Rationale |
|------|------|----------|
| `id` | `serial` PK | Auto-incrementing primary key |
| `referred_for` | `text` NOT NULL | Reason on why the patient is referred for. Required; a referral without a reason should be meaningless. |
| `referred_to` | `text` | Destination clinic / hospital(?). New field, rationale is to captures the referral target. |
| `referral_notes` | `text` | Free-text notes about the referral. |
| `referral_state` | `referral_state` enum, default `'pending'` | Aim to introduce lifecycle state (`pending` / `completed` / `cancelled`).|
| `referral_outcome` | `text` | Free-form result of the referral. Kept as text— treated as a narrative outcome instead |
| `consult_id` | `integer` NOT NULL, FK → `consults.id`, `ON DELETE restrict` | Every referral belongs to a consult. `restrict` prevents deleting a consult that still has referrals |
| `created_at` | `timestamp` DEFAULT `now()` NOT NULL | Records when the referral was made. Legacy had none (it imported `timezone` but never used it); referral date matters clinically. |

## Scope

Schema only, per #37. tRPC router, UI, and seed data if applicable will be out of scope and will follow in separate PRs to keep this PR lean.