### PR TITLE
158 eyesight visual acuity validation

### DIFF
--- a/src/__tests__/lib/validation/eyesight.test.ts
+++ b/src/__tests__/lib/validation/eyesight.test.ts
@@ -10,15 +10,17 @@ describe("visualAcuitySchema", () => {
     "6/24",
     "6/36",
     "6/60",
-    "6/60-",
-    "6/12+",
+    "6/120", // biggest E on the SOP chart
+    "6/9 +2", // passed 6/9, read 2 letters of the next line
+    "6/9+2", // space is optional
     "CF",
     "HM",
-    "PL",
-    "NPL",
-    "cf", // test for case-insensitive
-    "npl",
-    " 6/6 ", // have whitespace, to be trimmed before validation
+    "LP",
+    "NLP",
+    "cf", // case-insensitive
+    "lp",
+    "nlp",
+    " 6/6 ", // whitespace trimmed before validation
   ];
 
   it.each(valid)("accepts valid notation %j", (input) => {
@@ -29,10 +31,15 @@ describe("visualAcuitySchema", () => {
     "66",
     "6-6",
     "6/7", // not a standard denominator
+    "6/2", // clinically nonsensical
     "6/",
     "20/20", // imperial not accepted
     "garbage",
     "6/6++",
+    "6/12+", // "+" must carry a letter count
+    "6/9 -2", // SOP uses "+" only, not "-"
+    "PL", // clinic uses LP, not PL
+    "NPL", // clinic uses NLP, not NPL
     "PLL",
   ];
 
@@ -51,7 +58,7 @@ describe("visualAcuitySchema", () => {
 
 describe("pinholeSchema", () => {
   it("accepts every acuity value the degree fields accept", () => {
-    for (const v of ["6/6", "6/60", "6/12+", "CF", "HM", "PL", "NPL"]) {
+    for (const v of ["6/6", "6/60", "6/120", "6/9 +2", "CF", "HM", "LP", "NLP"]) {
       expect(pinholeSchema.safeParse(v).success).toBe(true);
     }
   });
@@ -62,7 +69,7 @@ describe("pinholeSchema", () => {
   });
 
   it("rejects the same malformed values as the acuity schema", () => {
-    for (const v of ["6/2", "20/20", "garbage", "PLL"]) {
+    for (const v of ["6/2", "20/20", "garbage", "PL", "PLL"]) {
       expect(pinholeSchema.safeParse(v).success).toBe(false);
     }
   });

--- a/src/__tests__/lib/validation/eyesight.test.ts
+++ b/src/__tests__/lib/validation/eyesight.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { visualAcuitySchema, pinholeSchema } from "@/lib/validation/eyesight";
+
+describe("visualAcuitySchema", () => {
+  const valid = [
+    "6/6",
+    "6/9",
+    "6/12",
+    "6/18",
+    "6/24",
+    "6/36",
+    "6/60",
+    "6/60-",
+    "6/12+",
+    "CF",
+    "HM",
+    "PL",
+    "NPL",
+    "cf", // test for case-insensitive
+    "npl",
+    " 6/6 ", // have whitespace, to be trimmed before validation
+  ];
+
+  it.each(valid)("accepts valid notation %j", (input) => {
+    expect(visualAcuitySchema.safeParse(input).success).toBe(true);
+  });
+
+  const invalid = [
+    "66",
+    "6-6",
+    "6/7", // not a standard denominator
+    "6/",
+    "20/20", // imperial not accepted
+    "garbage",
+    "6/6++",
+    "PLL",
+  ];
+
+  it.each(invalid)("rejects invalid notation %j", (input) => {
+    expect(visualAcuitySchema.safeParse(input).success).toBe(false);
+  });
+
+  it("treats empty string as not recorded (valid)", () => {
+    expect(visualAcuitySchema.safeParse("").success).toBe(true);
+  });
+
+  it("treats undefined as not recorded (valid, field is optional)", () => {
+    expect(visualAcuitySchema.safeParse(undefined).success).toBe(true);
+  });
+});
+
+describe("pinholeSchema", () => {
+  it("accepts every acuity value the degree fields accept", () => {
+    for (const v of ["6/6", "6/60", "6/12+", "CF", "HM", "PL", "NPL"]) {
+      expect(pinholeSchema.safeParse(v).success).toBe(true);
+    }
+  });
+
+  it("additionally accepts NI (no improvement), case-insensitive", () => {
+    expect(pinholeSchema.safeParse("NI").success).toBe(true);
+    expect(pinholeSchema.safeParse("ni").success).toBe(true);
+  });
+
+  it("rejects the same malformed values as the acuity schema", () => {
+    for (const v of ["6/2", "20/20", "garbage", "PLL"]) {
+      expect(pinholeSchema.safeParse(v).success).toBe(false);
+    }
+  });
+
+  it("treats empty/undefined as not recorded", () => {
+    expect(pinholeSchema.safeParse("").success).toBe(true);
+    expect(pinholeSchema.safeParse(undefined).success).toBe(true);
+  });
+});
+
+describe("NI is pinhole-only", () => {
+  it("is rejected by the visual acuity (degree) schema", () => {
+    // "NI" (no improvement) is only meaningful for a pinhole test, so the
+    // plain acuity/degree fields must not accept it.
+    expect(visualAcuitySchema.safeParse("NI").success).toBe(false);
+  });
+
+  it("is accepted by the pinhole schema", () => {
+    expect(pinholeSchema.safeParse("NI").success).toBe(true);
+  });
+});

--- a/src/__tests__/lib/validation/eyesight.test.ts
+++ b/src/__tests__/lib/validation/eyesight.test.ts
@@ -11,8 +11,12 @@ describe("visualAcuitySchema", () => {
     "6/36",
     "6/60",
     "6/120", // biggest E on the SOP chart
+    "6/7.5", // in database; SOP confirmation pending
+    "6/15", // in database; SOP confirmation pending
     "6/9 +2", // passed 6/9, read 2 letters of the next line
     "6/9+2", // space is optional
+    "6/9 -2", // missed 2 letters on the 6/9 line
+    "6/9-2", // space is optional
     "CF",
     "HM",
     "LP",
@@ -37,7 +41,6 @@ describe("visualAcuitySchema", () => {
     "garbage",
     "6/6++",
     "6/12+", // "+" must carry a letter count
-    "6/9 -2", // SOP uses "+" only, not "-"
     "PL", // clinic uses LP, not PL
     "NPL", // clinic uses NLP, not NPL
     "PLL",
@@ -52,6 +55,10 @@ describe("visualAcuitySchema", () => {
     expect(visualAcuitySchema.parse("nlp")).toBe("NLP");
     expect(visualAcuitySchema.parse(" lp ")).toBe("LP"); // trims too
     expect(visualAcuitySchema.parse("6/9 +2")).toBe("6/9 +2"); // numeric unchanged
+  });
+
+  it("trims whitespace before validation", () => {
+    expect(visualAcuitySchema.parse(" 6/9 +2 ")).toBe("6/9 +2");
   });
 
   it("treats empty string as not recorded (valid)", () => {

--- a/src/__tests__/lib/validation/eyesight.test.ts
+++ b/src/__tests__/lib/validation/eyesight.test.ts
@@ -47,6 +47,13 @@ describe("visualAcuitySchema", () => {
     expect(visualAcuitySchema.safeParse(input).success).toBe(false);
   });
 
+  it("normalizes low-vision codes to uppercase", () => {
+    expect(visualAcuitySchema.parse("cf")).toBe("CF");
+    expect(visualAcuitySchema.parse("nlp")).toBe("NLP");
+    expect(visualAcuitySchema.parse(" lp ")).toBe("LP"); // trims too
+    expect(visualAcuitySchema.parse("6/9 +2")).toBe("6/9 +2"); // numeric unchanged
+  });
+
   it("treats empty string as not recorded (valid)", () => {
     expect(visualAcuitySchema.safeParse("").success).toBe(true);
   });
@@ -58,7 +65,16 @@ describe("visualAcuitySchema", () => {
 
 describe("pinholeSchema", () => {
   it("accepts every acuity value the degree fields accept", () => {
-    for (const v of ["6/6", "6/60", "6/120", "6/9 +2", "CF", "HM", "LP", "NLP"]) {
+    for (const v of [
+      "6/6",
+      "6/60",
+      "6/120",
+      "6/9 +2",
+      "CF",
+      "HM",
+      "LP",
+      "NLP",
+    ]) {
       expect(pinholeSchema.safeParse(v).success).toBe(true);
     }
   });

--- a/src/components/vision/EyesightForm.tsx
+++ b/src/components/vision/EyesightForm.tsx
@@ -1,5 +1,6 @@
-import { useFormContext } from "react-hook-form";
+import { RegisterOptions, useFormContext } from "react-hook-form";
 import { useEffect } from "react";
+import { visualAcuitySchema, pinholeSchema } from "@/lib/validation/eyesight";
 import { trpc } from "@/utils/trpc";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { RHFInput } from "@/components/interactive/RHF/RHFInput";
@@ -20,22 +21,55 @@ const BLANK_EYESIGHT: EyesightFormValues = {
   comments: "",
 };
 
+// Validate a Visual Acuity field against the shared Zod schema so the client
+// and server enforce the exact same rule. Returns true when valid, or the
+// error message string RHF should display.
+const validateVisualAcuity: RegisterOptions["validate"] = (value) => {
+  const result = visualAcuitySchema.safeParse(value ?? "");
+  return result.success || result.error.issues[0]?.message;
+};
+
+const validatePinhole: RegisterOptions["validate"] = (value) => {
+  const result = pinholeSchema.safeParse(value ?? "");
+  return result.success || result.error.issues[0]?.message;
+};
+
 const EYE_SECTIONS: {
   title: string;
-  fields: { name: keyof EyesightFormValues; label: string }[];
+  fields: {
+    name: keyof EyesightFormValues;
+    label: string;
+    registerOptions?: RegisterOptions;
+  }[];
 }[] = [
   {
     title: "Visual Acuity (Degree)",
     fields: [
-      { name: "leftEyeDegree", label: "Left Eye Degree" },
-      { name: "rightEyeDegree", label: "Right Eye Degree" },
+      {
+        name: "leftEyeDegree",
+        label: "Left Eye Degree",
+        registerOptions: { validate: validateVisualAcuity },
+      },
+      {
+        name: "rightEyeDegree",
+        label: "Right Eye Degree",
+        registerOptions: { validate: validateVisualAcuity },
+      },
     ],
   },
   {
     title: "Pinhole",
     fields: [
-      { name: "leftEyePinhole", label: "Left Eye Pinhole" },
-      { name: "rightEyePinhole", label: "Right Eye Pinhole" },
+      {
+        name: "leftEyePinhole",
+        label: "Left Eye Pinhole",
+        registerOptions: { validate: validatePinhole },
+      },
+      {
+        name: "rightEyePinhole",
+        label: "Right Eye Pinhole",
+        registerOptions: { validate: validatePinhole },
+      },
     ],
   },
   {
@@ -146,6 +180,7 @@ export function EyesightForm({
                 name={field.name}
                 label={field.label}
                 type="text"
+                registerOptions={field.registerOptions}
               />
             ))}
           </div>

--- a/src/lib/validation/eyesight.ts
+++ b/src/lib/validation/eyesight.ts
@@ -22,7 +22,13 @@ export const PINHOLE_REGEX = new RegExp(`^(${ACUITY_PATTERN}|NI)$`, "i");
 
 // Optional, trimmed string field; empty string means "not recorded".
 const optionalField = (regex: RegExp, message: string) =>
-  z.string().trim().regex(regex, message).or(z.literal("")).optional();
+  z
+    .string()
+    .trim()
+    .regex(regex, message)
+    .toUpperCase()
+    .or(z.literal(""))
+    .optional();
 
 export const visualAcuitySchema = optionalField(
   VISUAL_ACUITY_REGEX,

--- a/src/lib/validation/eyesight.ts
+++ b/src/lib/validation/eyesight.ts
@@ -4,10 +4,15 @@ import { z } from "zod";
  * Shared, dependency-free validation primitives for eyesight fields,
  * safe to import on both server and client. Request-shape schemas live in the
  * router.
+ * 
+ * Per clinic SOP: Snellen fractions 6/6..6/120 (6m tumbling-E chart) with an
+ * optional "+N" for N letters read on the next line (e.g. "6/9 +2"), plus the
+ * low-vision codes CF (counting fingers), HM (hand movement),
+ * LP (light perception), NLP (no light perception).
  */
 
-// Snellen fractions (6/6..6/60, optional +/- suffix) plus low-vision codes: CF (counting fingers), HM (hand motion), PL/NPL (perception of light).
-const ACUITY_PATTERN = "6\\/(6|9|12|18|24|36|60)[+-]?|CF|HM|PL|NPL";
+const ACUITY_PATTERN =
+  "6\\/(6|9|12|18|24|36|60|120)(\\s*\\+\\d{1,2})?|CF|HM|LP|NLP";
 
 /** Visual acuity (degree) fields. Case-insensitive. */
 export const VISUAL_ACUITY_REGEX = new RegExp(`^(${ACUITY_PATTERN})$`, "i");
@@ -21,10 +26,10 @@ const optionalField = (regex: RegExp, message: string) =>
 
 export const visualAcuitySchema = optionalField(
   VISUAL_ACUITY_REGEX,
-  "Must be Snellen notation (e.g. 6/6, 6/12) or CF, HM, PL, NPL",
+  "Must be VA notation (e.g. 6/9, 6/9 +2, 6/120) or CF, HM, LP, NLP",
 );
 
 export const pinholeSchema = optionalField(
   PINHOLE_REGEX,
-  "Must be Snellen notation (e.g. 6/6, 6/12), CF, HM, PL, NPL, or NI",
+  "Must be VA notation (e.g. 6/9, 6/9 +2, 6/120), CF, HM, LP, NLP, or NI",
 );

--- a/src/lib/validation/eyesight.ts
+++ b/src/lib/validation/eyesight.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * Shared, dependency-free validation primitives for eyesight fields,
+ * safe to import on both server and client. Request-shape schemas live in the
+ * router.
+ */
+
+// Snellen fractions (6/6..6/60, optional +/- suffix) plus low-vision codes: CF (counting fingers), HM (hand motion), PL/NPL (perception of light).
+const ACUITY_PATTERN = "6\\/(6|9|12|18|24|36|60)[+-]?|CF|HM|PL|NPL";
+
+/** Visual acuity (degree) fields. Case-insensitive. */
+export const VISUAL_ACUITY_REGEX = new RegExp(`^(${ACUITY_PATTERN})$`, "i");
+
+/** Pinhole fields: acuity values plus "NI" (no improvement). Case-insensitive. */
+export const PINHOLE_REGEX = new RegExp(`^(${ACUITY_PATTERN}|NI)$`, "i");
+
+// Optional, trimmed string field; empty string means "not recorded".
+const optionalField = (regex: RegExp, message: string) =>
+  z.string().trim().regex(regex, message).or(z.literal("")).optional();
+
+export const visualAcuitySchema = optionalField(
+  VISUAL_ACUITY_REGEX,
+  "Must be Snellen notation (e.g. 6/6, 6/12) or CF, HM, PL, NPL",
+);
+
+export const pinholeSchema = optionalField(
+  PINHOLE_REGEX,
+  "Must be Snellen notation (e.g. 6/6, 6/12), CF, HM, PL, NPL, or NI",
+);

--- a/src/lib/validation/eyesight.ts
+++ b/src/lib/validation/eyesight.ts
@@ -4,15 +4,17 @@ import { z } from "zod";
  * Shared, dependency-free validation primitives for eyesight fields,
  * safe to import on both server and client. Request-shape schemas live in the
  * router.
- * 
+ *
  * Per clinic SOP: Snellen fractions 6/6..6/120 (6m tumbling-E chart) with an
- * optional "+N" for N letters read on the next line (e.g. "6/9 +2"), plus the
- * low-vision codes CF (counting fingers), HM (hand movement),
- * LP (light perception), NLP (no light perception).
+ * optional "+N"/"-N" suffix for letters read over/under on the next line
+ * (e.g. "6/9 +2", "6/9-2"), plus the low-vision codes CF (counting fingers),
+ * HM (hand movement), LP (light perception), NLP (no light perception).
+ *
+ * 6/7.5 and 6/15 are also accepted — they appear in the old db.
  */
 
 const ACUITY_PATTERN =
-  "6\\/(6|9|12|18|24|36|60|120)(\\s*\\+\\d{1,2})?|CF|HM|LP|NLP";
+  "6\\/(7\\.5|6|9|12|15|18|24|36|60|120)(\\s*[+-]\\d{1,2})?|CF|HM|LP|NLP";
 
 /** Visual acuity (degree) fields. Case-insensitive. */
 export const VISUAL_ACUITY_REGEX = new RegExp(`^(${ACUITY_PATTERN})$`, "i");
@@ -32,10 +34,10 @@ const optionalField = (regex: RegExp, message: string) =>
 
 export const visualAcuitySchema = optionalField(
   VISUAL_ACUITY_REGEX,
-  "Must be VA notation (e.g. 6/9, 6/9 +2, 6/120) or CF, HM, LP, NLP",
+  "Must be VA notation (e.g. 6/9, 6/9 +2, 6/9-2, 6/120) or CF, HM, LP, NLP",
 );
 
 export const pinholeSchema = optionalField(
   PINHOLE_REGEX,
-  "Must be VA notation (e.g. 6/9, 6/9 +2, 6/120), CF, HM, LP, NLP, or NI",
+  "Must be VA notation (e.g. 6/9, 6/9 +2, 6/9-2, 6/120), CF, HM, LP, NLP, or NI",
 );

--- a/src/pages/vision/update-glasses/[patientId].tsx
+++ b/src/pages/vision/update-glasses/[patientId].tsx
@@ -18,7 +18,9 @@ type UpdateGlassesFormValues = EyesightFormValues & { visitSelect: string };
 function UpdateGlassesPage() {
   const router = useRouter();
   const { patientId } = router.query;
-  const methods = useForm<UpdateGlassesFormValues>();
+  // "onTouched": validate acuity/pinhole fields after first blur, then live on
+  // every change,intended behavior is that  errors surface before Save and clear once input is valid
+  const methods = useForm<UpdateGlassesFormValues>({ mode: "onTouched" });
   const { setValue } = methods;
 
   const { data: patient, isLoading: patientLoading } =

--- a/src/server/routers/eyesight_router.ts
+++ b/src/server/routers/eyesight_router.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { router, protectedProcedure } from "@/server/trpc";
 import { db } from "@/db/drizzle";
-import { eyesight } from "@/db/schema/vitals";
+import { eyesight } from "@/db/schema";
+import { visualAcuitySchema, pinholeSchema } from "@/lib/validation/eyesight";
 
 /**
  * Common select fields for eyesight queries to ensure consistency
@@ -24,13 +25,16 @@ const selectEyesightFields = {
 
 /**
  * Input validation schema for creating eyesight records.
+ * Acuity (degree) and pinhole fields are format-validated via shared schemas;
+ * astigmatism and prescribed-glasses fields remain free text pending
+ * confirmation of the clinic's dioptric recording convention.
  */
 const createEyesightInput = z.object({
   visitId: z.number().int().positive(),
-  leftEyeDegree: z.string().optional(),
-  rightEyeDegree: z.string().optional(),
-  leftEyePinhole: z.string().optional(),
-  rightEyePinhole: z.string().optional(),
+  leftEyeDegree: visualAcuitySchema,
+  rightEyeDegree: visualAcuitySchema,
+  leftEyePinhole: pinholeSchema,
+  rightEyePinhole: pinholeSchema,
   leftAstigmatism: z.string().optional(),
   rightAstigmatism: z.string().optional(),
   comments: z.string().optional(),


### PR DESCRIPTION
Closes #158 

## Description

- Adds format validation for eyesight visual acuity and pinhole fields which were previously stored as text-free unvalidated. Validation is defined and enforced identically on client (form) and server (tRPC). Notation should follow the clinic's VA measurement SOP from last year.

## Changes

- `src/lib/validation/eyesight.ts` — shared validation primitives (safe to import on both client and server):
- `src/server/routers/eyesight_router.ts` — `createEyesightInput/updateEyesightInput` now validate the acuity + pinhole fields via the shared schemas. Normalization happens here on parse(), so the DB stores canonical values.
-` src/components/vision/EyesightForm.tsx` — the Visual Acuity and Pinhole inputs validate against the same schemas via react-hook-form, so **invalid entries are caught before submit** with the same rule the server enforces.
- src/__tests__/lib/validation/eyesight.test.ts — addition of unit tests.

## Automated Test Plan
- [ ] pnpm test:run src/__tests__/lib/validation/eyesight.test.ts — test case passes
- [ ] npx tsc --noEmit and eslint clean on the changed files

## Manual Test Plan
- [x] Open a patient's vision/update-glasses page.
- [ ] Enter an invalid acuity (e.g. 20/20 or 6/7) in a Degree field → inline error shown, save blocked.
- [ ] Enter 6/9 +2 and CF → accepted.
- [ ] Enter NI in a Pinhole field → accepted; enter NI in a Degree field → rejected.
- [ ] Enter lowercase lp, save, reload → persists as LP.
- [ ] Leave a field blank → saves fine (optional).
- [ ] Confirm astigmatism / prescribed-glasses fields still accept free text.

