### PR TITLE
164 improve checkbox appearance

### DIFF
--- a/src/components/interactive/RHF/RHFInput.tsx
+++ b/src/components/interactive/RHF/RHFInput.tsx
@@ -68,27 +68,23 @@ export function RHFInput({
 
   if (isCheckbox) {
     return (
-      <div
-        className={`grid grid-cols-[1fr_auto] items-center gap-4 py-3 px-3 rounded-md hover:bg-gray-50 transition ${className}`}
+      <label
+        htmlFor={name}
+        className={`grid grid-cols-[1fr_auto] items-center gap-4 py-3 px-3 rounded-md hover:bg-gray-50 transition cursor-pointer ${className}`}
       >
-        {/* LEFT: LABEL */}
-        <label
-          htmlFor={name}
-          className="text-sm font-semibold text-gray-800 justify-self-start cursor-pointer"
-        >
+        <span className="text-sm font-semibold text-gray-800 justify-self-start">
           {label}
           <IsRequiredStar isRequired={isRequired} />
-        </label>
+        </span>
 
-        {/* RIGHT: CHECKBOX (aligned in one column) */}
         <input
           id={name}
           type="checkbox"
           {...registerProps}
           {...props}
-          className="h-4 w-4 accent-blue-500 cursor-pointer border-gray-300 rounded justify-self-end focus:ring-2 focus:ring-blue-400"
+          className="h-4 w-4 shrink-0 accent-blue-500 cursor-pointer border-gray-300 rounded justify-self-end focus:ring-2 focus:ring-blue-400"
         />
-      </div>
+      </label>
     );
   }
 

--- a/src/components/interactive/RHF/RHFInput.tsx
+++ b/src/components/interactive/RHF/RHFInput.tsx
@@ -82,7 +82,7 @@ export function RHFInput({
           type="checkbox"
           {...registerProps}
           {...props}
-          className="h-4 w-4 shrink-0 accent-blue-500 cursor-pointer border-gray-300 rounded justify-self-end focus:ring-2 focus:ring-blue-400"
+          className="h-4 w-4 accent-blue-500 cursor-pointer border-gray-300 rounded justify-self-end focus:ring-2 focus:ring-blue-400"
         />
       </label>
     );

--- a/src/components/interactive/inputs/WebcamInput.tsx
+++ b/src/components/interactive/inputs/WebcamInput.tsx
@@ -74,7 +74,7 @@ export function WebcamInput({
           <Button title="Capture" colour="emerald" onClick={webcamCapture} />
         </div>
       )}
-      <div className="mt-2 flex items-center justify-center">
+      <div className="mt-6 flex items-center justify-center">
         {!cameraIsOpen ? (
           imageDetails == null ? (
             <Button

--- a/src/components/scanFace/MatchingPatients.tsx
+++ b/src/components/scanFace/MatchingPatients.tsx
@@ -7,6 +7,7 @@ import { PatientPhoto } from "@/components/PatientPhoto";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { Mode } from "@/types/scan";
 import { Button } from "@/components/interactive/Button/Button";
+import { MdPersonSearch } from "react-icons/md";
 
 export default function MatchingPatients({
   imgDetails,
@@ -51,15 +52,21 @@ export default function MatchingPatients({
 
   if (searchPatientsByPictureQuery.data.length === 0) {
     return (
-      <div className="flex-col">
-        <h2 className="text-xl font-bold mb-4 text-center py-10">
+      <div className="flex flex-col items-center gap-3 py-6 text-center">
+        <MdPersonSearch className="text-gray-300" size={64} />
+        <h2 className="text-lg font-semibold text-gray-700">
           No matches found
         </h2>
-        <Button
-          onClick={() => setMode(Mode.REGISTERING)}
-          colour="indigo"
-          title="Register New Patient"
-        />
+        <p className="text-sm text-gray-400">
+          We couldn&apos;t find a patient matching this face.
+        </p>
+        <div className="flex gap-3 mt-4">
+          <Button
+            onClick={() => setMode(Mode.REGISTERING)}
+            colour="indigo"
+            title="Register New Patient"
+          />
+        </div>
       </div>
     );
   }
@@ -96,7 +103,7 @@ export default function MatchingPatients({
           ))}
         </tbody>
       </table>
-      <div className="flex gap-3 mt-6">
+      <div className="flex gap-3 mt-6 justify-center">
         <Button
           colour="indigo"
           onClick={() => setMode(Mode.REGISTERING)}

--- a/src/components/scanFace/RegistrationPage.tsx
+++ b/src/components/scanFace/RegistrationPage.tsx
@@ -110,24 +110,19 @@ export default function RegistrationPage({
             type="date"
             isRequired
           />
-          <RHFInput
-            name="hasPoorCard"
-            label="Has POOR Card?"
-            type="checkbox"
-            className="flex flex-row-reverse"
-          />
-          <RHFInput
-            name="hasBS2Card"
-            label="Has BS2 Card?"
-            type="checkbox"
-            className="flex flex-row-reverse"
-          />
-          <RHFInput
-            name="hasSabaiCard"
-            label="Has Sabai Card?"
-            type="checkbox"
-            className="flex flex-row-reverse"
-          />
+          <div className="rounded-lg border border-gray-200 bg-gray-50 divide-y divide-gray-200">
+            <RHFInput
+              name="hasPoorCard"
+              label="Has POOR Card?"
+              type="checkbox"
+            />
+            <RHFInput name="hasBS2Card" label="Has BS2 Card?" type="checkbox" />
+            <RHFInput
+              name="hasSabaiCard"
+              label="Has Sabai Card?"
+              type="checkbox"
+            />
+          </div>
 
           {/* Submit Button */}
           <div className="flex gap-3 mt-6 justify-center">


### PR DESCRIPTION
Closes #164 

## Description
- Bunch of small UI improvements to the scan face flow, in particular the registration form checkboxes and matching patients empty state
- Rendered the checkboxes in a container with row dividers to make it clear they belong together as a group.
- Replaced the plain bold centered heading with a softer layout: a large muted `MdPersonSearch` icon, a lighter-weight heading, and an explanatory subtext line. 
- Increased top margin on the button row below the webcam from mt-2 to mt-6 for breathing room.

## Test plan
- [x] Card checkboxes render as a grouped card with dividers between rows
- [x] Checkbox does not visually collapse at narrow viewport widths
- [x] Scan a face with no matching patient — empty state shows icon, heading, and subtext, not a plain bold heading
- [x]  All other `RHFInput` types (text, date, dropdown) are unaffected