### PR TITLE
163 add referral routers

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -28,5 +28,38 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      #  CI boots the full local Supabase stack instead of mocking the database.
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.72.7
+
+      # `supabase start` applies the migrations in supabase/migrations.
+      - name: Start Supabase
+        run: supabase start
+
+      # Map the generated credentials onto the env var names that src/lib/envVariables.ts validates.
+      # The Cloudinary/AWS vars aren't exercised by the tests but must be non-empty
+      # to pass schema validation at import time.
+      - name: Export environment variables
+        run: |
+          eval "$(supabase status -o env)"
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=${API_URL}"
+            echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${PUBLISHABLE_KEY}"
+            echo "SUPABASE_SECRET_KEY=${SECRET_KEY}"
+            echo "DATABASE_URL=${DB_URL}"
+            echo "CLOUDINARY_URL_PREFIX=https://res.cloudinary.com/ci-dummy"
+            echo "CLOUDINARY_URL=cloudinary://000000000000000:ci-dummy-secret@ci-dummy"
+            echo "AWS_ACCESS_KEY_ID=ci-dummy"
+            echo "AWS_SECRET_ACCESS_KEY=ci-dummy"
+            echo "AWS_REGION=ap-southeast-1"
+            echo "COLLECTION_ID=ci-dummy"
+          } >> "$GITHUB_ENV"
+
+      # The integration tests read an existing auth.users row for the doctor FK.
+      - name: Seed users
+        run: pnpm seed:users
+
       - name: Run Vitest
         run: pnpm vitest run

--- a/src/__tests__/server/routers/referral_router.test.ts
+++ b/src/__tests__/server/routers/referral_router.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment node
+//
+// Integration tests for the referral tRPC router. These run against a real
+// Postgres (the local Supabase instance on 127.0.0.1:54322) so the joins,
+// enum handling, and FK constraints are exercised for real
+// Prereqs: `supabase start` (or `pnpm seed:db`) so migrations are applied, and at least one auth.users row (`pnpm seed:users`).
+//
+// Runs in the node environment (not jsdom) because src/lib/envVariables.ts
+// switches on `typeof window` and only exposes DATABASE_URL server-side.
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { appRouter } from "@/server/routers/_app";
+import { db } from "@/db/drizzle";
+import type { Context } from "@/server/context";
+import {
+  referrals,
+  consults,
+  visits,
+  patients,
+  villageCodes,
+  authUsers,
+} from "@/db/schema";
+
+// Fixture inserted into Postgres for the FK chain (not mocks).
+const SEED_PATIENT = {
+  name: "Referral Test Patient",
+  gender: "female",
+  drugAllergy: "NKDA", // NKDA stands for "No Known Drug Allergies"
+  dateOfBirth: new Date("1990-01-01"),
+  hasPoorCard: false,
+  hasBS2Card: false,
+  hasSabaiCard: false,
+  patientImagePublicId: "test/placeholder",
+} as const;
+
+const VILLAGE_CODE = {
+  code: "SATBB",
+  name: "SATBB Village",
+  colorHex: "#C0392B",
+};
+
+// protectedProcedure only reads ctx.user, so a minimal context is enough.
+function callerFor(userId: string) {
+  return appRouter.createCaller({ user: { id: userId } } as unknown as Context);
+}
+
+describe("referralRouter (integration)", () => {
+  let doctorId: string;
+  let villageCodeId: number;
+  let patientId: number;
+  let visitId: number;
+  let consultId: number;
+  let caller: ReturnType<typeof callerFor>;
+
+  beforeAll(async () => {
+    // A consult FK-references auth.users; reuse an existing seeded user.
+    const [doctor] = await db
+      .select({ id: authUsers.id })
+      .from(authUsers)
+      .limit(1);
+    if (!doctor) {
+      throw new Error(
+        "No auth.users row found. Run `pnpm seed:all` against local Supabase " +
+          "before running the router integration tests.",
+      );
+    }
+    doctorId = doctor.id;
+
+    [{ id: villageCodeId }] = await db
+      .insert(villageCodes)
+      .values({
+        code: VILLAGE_CODE.code,
+        name: VILLAGE_CODE.name,
+        colorHex: VILLAGE_CODE.colorHex,
+      })
+      .returning({ id: villageCodes.id });
+
+    [{ id: patientId }] = await db
+      .insert(patients)
+      .values(SEED_PATIENT)
+      .returning({ id: patients.id });
+
+    [{ id: visitId }] = await db
+      .insert(visits)
+      .values({ patientId, villageCodeId })
+      .returning({ id: visits.id });
+
+    [{ id: consultId }] = await db
+      .insert(consults)
+      .values({ doctorId, visitId })
+      .returning({ id: consults.id });
+
+    caller = callerFor(doctorId);
+  });
+
+  // Each test creates its own referrals; wipe them so counts stay deterministic.
+  afterEach(async () => {
+    await db.delete(referrals).where(eq(referrals.consultId, consultId));
+  });
+
+  // Tear down the seed chain in FK-dependency order.
+  afterAll(async () => {
+    await db.delete(referrals).where(eq(referrals.consultId, consultId));
+    await db.delete(consults).where(eq(consults.id, consultId));
+    await db.delete(visits).where(eq(visits.id, visitId));
+    await db.delete(patients).where(eq(patients.id, patientId));
+    await db.delete(villageCodes).where(eq(villageCodes.id, villageCodeId));
+  });
+
+  describe("create()", () => {
+    // Calls create with only consultId and referredFor (no notes)
+    it("defaults state to New and notes to null when omitted", async () => {
+      const created = await caller.referralRouter.create({
+        consultId,
+        referredFor: "Cardiology",
+      });
+      expect(created.referralState).toBe("New");
+      expect(created.referralNotes).toBeNull();
+      expect(created.consultId).toBe(consultId);
+    });
+  });
+
+  describe("list()", () => {
+    // Confirm that the joins actually resolve and returns the enriched fields (patientName, doctorId, etc.) rather than just the raw referrals table.
+    it("enriches referrals via the patient/consult joins", async () => {
+      await caller.referralRouter.create({
+        consultId,
+        referredFor: "Dermatology",
+        referralNotes: "urgent",
+      });
+      const rows = await caller.referralRouter.list();
+      const row = rows.find((r) => r.consultId === consultId);
+      expect(row).toBeDefined();
+      expect(row!.patientId).toBe(patientId);
+      expect(row!.patientName).toBe(SEED_PATIENT.name);
+      expect(row!.doctorId).toBe(doctorId);
+      expect(row!.referralNotes).toBe("urgent");
+    });
+  });
+
+  describe("getById()", () => {
+    it("returns the enriched referral, or null when missing", async () => {
+      const created = await caller.referralRouter.create({
+        consultId,
+        referredFor: "Ortho",
+      });
+      const found = await caller.referralRouter.getById({ id: created.id });
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(created.id);
+      expect(found!.patientName).toBe(SEED_PATIENT.name);
+
+      expect(await caller.referralRouter.getById({ id: -1 })).toBeNull();
+    });
+  });
+
+  describe("getByConsultId()", () => {
+    // Create 2 referrals for same consult, then query by consutlId, verify that it returns both and that the consultId matches.
+    it("returns every referral for the consult", async () => {
+      await caller.referralRouter.create({ consultId, referredFor: "A" });
+      await caller.referralRouter.create({ consultId, referredFor: "B" });
+      const rows = await caller.referralRouter.getByConsultId({ consultId });
+      expect(rows).toHaveLength(2);
+      expect(rows.every((r) => r.consultId === consultId)).toBe(true);
+    });
+  });
+
+  describe("updateState()", () => {
+    it("updates state and outcome", async () => {
+      const created = await caller.referralRouter.create({
+        consultId,
+        referredFor: "Neurological Disorders",
+      });
+      const updated = await caller.referralRouter.updateState({
+        id: created.id,
+        referralState: "CompletedSuccess",
+        referralOutcome: "Patient seen and treated",
+      });
+      expect(updated).not.toBeNull();
+      expect(updated!.referralState).toBe("CompletedSuccess");
+      expect(updated!.referralOutcome).toBe("Patient seen and treated");
+    });
+
+    // Confirm that zod rejects an invalid enum value, rather than passing it to the database.
+    // This may not happen as they will be selecting from dropdown options, but it's a good safety check.
+    it("rejects a state outside the enum", async () => {
+      const created = await caller.referralRouter.create({
+        consultId,
+        referredFor: "X",
+      });
+      await expect(
+        caller.referralRouter.updateState({
+          id: created.id,
+          // @ts-expect-error invalid enum value must be rejected by zod
+          referralState: "Bogus value",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("delete()", () => {
+    it("reports success only when a row was removed", async () => {
+      const created = await caller.referralRouter.create({
+        consultId,
+        referredFor: "Uveitis (Inflammation of the uvea)",
+      });
+      expect(await caller.referralRouter.delete({ id: created.id })).toEqual({
+        success: true,
+      });
+      expect(await caller.referralRouter.delete({ id: created.id })).toEqual({
+        success: false,
+      });
+    });
+  });
+});

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -11,6 +11,7 @@ import { visitsRouter } from "./visits_router";
 import { vitalsRouter } from "./vitals_router";
 import { eyesightRouter } from "./eyesight_router";
 import { consultsRouter } from "./consults_router";
+import { referralRouter } from "./referral_router";
 
 export const appRouter = router({
   healthcheck: publicProcedure.query(() => "yay!"),
@@ -24,6 +25,7 @@ export const appRouter = router({
   vitalsRouter: vitalsRouter,
   eyesightRouter: eyesightRouter,
   consultsRouter: consultsRouter,
+  referralRouter: referralRouter,
 });
 
 export const createCaller = createCallerFactory(appRouter);

--- a/src/server/routers/referral_router.ts
+++ b/src/server/routers/referral_router.ts
@@ -1,18 +1,16 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "@/server/trpc";
 import { db } from "@/db/drizzle";
-import { referrals, consults, visits, patients } from "@/db/schema";
+import {
+  referrals,
+  consults,
+  visits,
+  patients,
+  referralStateEnum,
+} from "@/db/schema";
 import { eq, desc } from "drizzle-orm";
 
-const referralStateSchema = z.enum([
-  "New",
-  "Seen",
-  "Outgoing",
-  "Completed",
-  "CompletedSuccess",
-  "CompletedFailure",
-  "None",
-]);
+const referralStateSchema = z.enum(referralStateEnum.enumValues);
 
 export const referralRouter = router({
   // List all referrals enriched with patient, doctor, and date

--- a/src/server/routers/referral_router.ts
+++ b/src/server/routers/referral_router.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import { router, protectedProcedure } from "@/server/trpc";
+import { db } from "@/db/drizzle";
+import { referrals, consults, visits, patients } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+
+const referralStateSchema = z.enum([
+  "New",
+  "Seen",
+  "Outgoing",
+  "Completed",
+  "CompletedSuccess",
+  "CompletedFailure",
+  "None",
+]);
+
+export const referralRouter = router({
+  // List all referrals enriched with patient, doctor, and date
+  list: protectedProcedure.query(async () => {
+    const result = await db
+      .select({
+        id: referrals.id,
+        referredFor: referrals.referredFor,
+        referralNotes: referrals.referralNotes,
+        referralState: referrals.referralState,
+        referralOutcome: referrals.referralOutcome,
+        consultId: referrals.consultId,
+        createdAt: referrals.createdAt,
+        consultDate: consults.date,
+        doctorId: consults.doctorId,
+        patientId: patients.id,
+        patientName: patients.name,
+      })
+      .from(referrals)
+      .innerJoin(consults, eq(referrals.consultId, consults.id))
+      .innerJoin(visits, eq(consults.visitId, visits.id))
+      .innerJoin(patients, eq(visits.patientId, patients.id))
+      .orderBy(desc(referrals.createdAt));
+
+    return result;
+  }),
+
+  // Get a single referral by ID with full enrichment
+  getById: protectedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .query(async ({ input }) => {
+      const [result] = await db
+        .select({
+          id: referrals.id,
+          referredFor: referrals.referredFor,
+          referralNotes: referrals.referralNotes,
+          referralState: referrals.referralState,
+          referralOutcome: referrals.referralOutcome,
+          consultId: referrals.consultId,
+          createdAt: referrals.createdAt,
+          consultDate: consults.date,
+          doctorId: consults.doctorId,
+          patientId: patients.id,
+          patientName: patients.name,
+        })
+        .from(referrals)
+        .innerJoin(consults, eq(referrals.consultId, consults.id))
+        .innerJoin(visits, eq(consults.visitId, visits.id))
+        .innerJoin(patients, eq(visits.patientId, patients.id))
+        .where(eq(referrals.id, input.id))
+        .limit(1);
+
+      return result || null;
+    }),
+
+  // Get all referrals for a consult
+  getByConsultId: protectedProcedure
+    .input(z.object({ consultId: z.number().int() }))
+    .query(async ({ input }) => {
+      const result = await db
+        .select()
+        .from(referrals)
+        .where(eq(referrals.consultId, input.consultId))
+        .orderBy(desc(referrals.createdAt));
+
+      return result;
+    }),
+
+  // Create a referral — called by the Frontend after POST /consults/
+  create: protectedProcedure
+    .input(
+      z.object({
+        consultId: z.number().int(),
+        referredFor: z.string().min(1),
+        referralNotes: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const [newReferral] = await db
+        .insert(referrals)
+        .values({
+          consultId: input.consultId,
+          referredFor: input.referredFor,
+          referralNotes: input.referralNotes ?? null,
+          referralState: "New",
+        })
+        .returning();
+
+      return newReferral;
+    }),
+
+  // Update referral state and outcome
+  updateState: protectedProcedure
+    .input(
+      z.object({
+        id: z.number().int(),
+        referralState: referralStateSchema,
+        referralOutcome: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { id, ...updateData } = input;
+      const [result] = await db
+        .update(referrals)
+        .set(updateData)
+        .where(eq(referrals.id, id))
+        .returning();
+
+      return result || null;
+    }),
+
+  // Delete a referral
+  delete: protectedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .mutation(async ({ input }) => {
+      const [result] = await db
+        .delete(referrals)
+        .where(eq(referrals.id, input.id))
+        .returning({ id: referrals.id });
+
+      return { success: !!result };
+    }),
+});

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,8 +1,15 @@
 import "@testing-library/jest-dom";
+// Load .env into process.env so server/router integration tests (node
+// environment) can read DATABASE_URL and the other server-only vars validated
+// by src/lib/envVariables.ts. Harmless for jsdom component tests.
+import "dotenv/config";
 
 // Workaround for vitest - mock HTMLDialogElement methods
 // https://github.com/jsdom/jsdom/issues/3294
 beforeAll(() => {
+  // Server/router integration tests run with `@vitest-environment node`, where window is undefined.
+  if (typeof window === "undefined") return;
+
   HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
     this.setAttribute("open", "");
   });


### PR DESCRIPTION
Closes #163 

## Description 

- Adds a tRPC referral router (`referralRouter`) exposing CRUD operations over the `referrals` table, wired into the app router. Includes the repo's first router-level integration tests too ;D

## Changes

- `src/server/routers/referral_router.ts` — new router with six procedures:
  - `list` — all referrals, enriched with patient/doctor/consult data
  - `getById` — single enriched referral, or `null` if not found
  - `getByConsultId` — all referrals for a consult
  - `create` — insert a referral (defaults `referralState` to `New` )
  - `updateState` — update state + outcome
  - `delete` — remove a referral, returns `{ success }`
- `src/test-setup.ts` — load `.env` via `dotenv/config` and guard the DOM  shims with a `typeof window` check so node-environment tests can run alongside the existing jsdom component tests.
- `src/__tests__/server/routers/referral_router.test.ts` — adding of integration tests to procedures

## Test plan
- Prerequisites: local Supabase running with migrations + a seeded user.
- Run the referral tests:

```
npx vitest run src/__tests__/server/routers/referral_router.test.ts --no
```

- [ ] `create()` defaults state to `New` and notes to `null` when omitted
- [ ] `list()` returns rows enriched via the patient/consult joins (`patientName`, `doctorId`)
- [ ] `getById()` returns the enriched referral, and `null` for a missing id
- [ ] `getByConsultId()` returns every referral for a consult (referral have FK to consult)
- [ ] `updateState()` rejects a state outside the enum (zod guard / validation)
- [ ] `delete()` reports `success: true` on a real delete, `false` on a repeat
