### PR TITLE
128 standardise visit dropdown header

### DIFF
--- a/src/components/interactive/PatientSearchResultItem.tsx
+++ b/src/components/interactive/PatientSearchResultItem.tsx
@@ -24,7 +24,7 @@ export default function PatientSearchResultItem({
         pictureUrl={patient.patientImageUrl}
         height={40}
         width={40}
-        className="rounded-full border border-slate-200"
+        className="rounded-lg border border-slate-200"
       />
       <div className="flex min-w-0 flex-col">
         <span className="font-medium truncate">{patient.name}</span>

--- a/src/components/interactive/inputs/FormSection.tsx
+++ b/src/components/interactive/inputs/FormSection.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from "react";
+
+/**
+ * A titled, card-style grouping for a set of related form fields. Gives long
+ * forms clear visual sections instead of one long scattered list.
+ */
+export default function FormSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="mb-4 border-b border-slate-100 pb-3">
+        <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+        {description && (
+          <p className="mt-1 text-sm text-slate-500">{description}</p>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/components/scanFace/MatchingPatients.tsx
+++ b/src/components/scanFace/MatchingPatients.tsx
@@ -87,7 +87,7 @@ export default function MatchingPatients({
               <TableCell>
                 <PatientPhoto
                   pictureUrl={patient.patientImageUrl}
-                  className="rounded-full border border-slate-200"
+                  className="rounded-lg border border-slate-200"
                 />
               </TableCell>
               <TableCell>

--- a/src/pages/patient/[id]/index.tsx
+++ b/src/pages/patient/[id]/index.tsx
@@ -85,7 +85,7 @@ export default function PatientPage() {
               pictureUrl={patient.patientImageUrl}
               height={64}
               width={64}
-              className="h-16 w-16 rounded-full object-cover border border-slate-200"
+              className="h-16 w-16 rounded-lg object-cover border border-slate-200"
             />
             <div>
               <h1 className="text-2xl font-semibold text-slate-900">

--- a/src/pages/patient/index.tsx
+++ b/src/pages/patient/index.tsx
@@ -83,7 +83,7 @@ function PatientsBasePage() {
                     </span>
                     <PatientPhoto
                       pictureUrl={patient.patientImageUrl}
-                      className="rounded-full border border-slate-200"
+                      className="rounded-lg border border-slate-200"
                     />
                   </div>
                 </TableCell>

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -354,23 +354,28 @@ function VitalsForm({ visitId }: { visitId: number }) {
         </div>
       </FormSection>
 
-      {/* Notes & diagnostics */}
+      {/* Urinalysis */}
       <FormSection
-        title="Diagnostics & Remarks"
-        description="Urinalysis findings and any additional clinical notes."
+        title="Urinalysis"
+        description="Urine test findings."
       >
-        <div className="space-y-4">
-          <RHFTextArea
-            name="urineTest"
-            label="Urinalysis Diagnostics (Leukocytes, Nitrites, Protein notes)"
-            rows={3}
-          />
-          <RHFTextArea
-            name="others"
-            label="Additional Clinical Remarks"
-            rows={3}
-          />
-        </div>
+        <RHFTextArea
+          name="urineTest"
+          label="Urinalysis Diagnostics (Leukocytes, Nitrites, Protein notes)"
+          rows={3}
+        />
+      </FormSection>
+
+      {/* Additional remarks */}
+      <FormSection
+        title="Additional Remarks"
+        description="Any additional clinical notes."
+      >
+        <RHFTextArea
+          name="others"
+          label="Additional Clinical Remarks"
+          rows={3}
+        />
       </FormSection>
 
       <div className="flex justify-end pt-2">

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -18,6 +18,7 @@ import { RHFTextArea } from "@/components/interactive/RHF/RHFTextArea";
 import { Button } from "@/components/interactive/Button/Button";
 import toast from "react-hot-toast";
 import { formatVisitDate } from "@/lib/utils/visit";
+import FormSection from "@/components/interactive/inputs/FormSection";
 
 type VitalsFormValues = {
   height?: string | null;
@@ -79,7 +80,7 @@ export default function PatientVitalsPage() {
   // Only check if patient is missing AFTER we are certain the query ran
   if (!patient) {
     return (
-      <div className="p-8 text-center font-semibold text-red-500">
+      <div className="p-5 text-center font-semibold text-red-500">
         Patient not found
       </div>
     );
@@ -91,7 +92,7 @@ export default function PatientVitalsPage() {
     : null;
 
   return (
-    <div className="min-h-screen flex-1 p-8 bg-slate-50">
+    <div className="min-h-screen flex-1 p-4 bg-slate-50">
       <div className="w-full mx-auto max-w-5xl">
         <Breadcrumbs
           items={[
@@ -106,12 +107,12 @@ export default function PatientVitalsPage() {
             Patient Vitals — {patient.name}
           </h1>
         </div>
-        <div className="flex-1 overflow-y-auto p-6">
-          <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-            <FormProvider {...methods}>
-              <div className="p-6 border-b border-slate-100 bg-slate-50/50">
-                {visits && visits.length > 0 ? (
-                  <div className="max-w-md">
+        <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+          <FormProvider {...methods}>
+            <div className="p-6 border-b border-slate-100 bg-slate-50/50">
+              {visits && visits.length > 0 ? (
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:items-center">
+                  <div className="w-full max-w-md">
                     <RHFDropdown
                       name="visitSelect"
                       label="Choose visit"
@@ -121,33 +122,35 @@ export default function PatientVitalsPage() {
                       }))}
                     />
                   </div>
-                ) : (
-                  <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg text-amber-700">
-                    No visits found for patient.
-                  </div>
-                )}
-              </div>
-
-              <div className="p-6">
-                {selectedVisit ? (
-                  <div className="mb-6 p-4 bg-blue-50/50 rounded-lg border border-blue-100">
-                    <span className="text-xs font-semibold text-blue-700 uppercase tracking-wider block mb-1">
-                      Filling up vitals form for visit on{" "}
-                      {formatVisitDate(selectedVisit.date)}
+                  <div className="text-center text-sm text-slate-600">
+                    Filling up vitals form for visit on{" "}
+                    <span className="font-semibold text-slate-900">
+                      {selectedVisit
+                        ? formatVisitDate(selectedVisit.date)
+                        : "-"}
                     </span>
-                    <VitalsForm visitId={selectedVisit.id} />
                   </div>
-                ) : (
-                  visits &&
-                  visits.length > 0 && (
-                    <div className="text-center py-12 text-slate-400 font-medium border-2 border-dashed border-slate-200 rounded-xl">
-                      Please choose a visit to view vitals.
-                    </div>
-                  )
-                )}
-              </div>
-            </FormProvider>
-          </div>
+                </div>
+              ) : (
+                <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg text-amber-700">
+                  No visits found for patient.
+                </div>
+              )}
+            </div>
+
+            <div className="bg-slate-50/50 p-6">
+              {selectedVisit ? (
+                <VitalsForm visitId={selectedVisit.id} />
+              ) : (
+                visits &&
+                visits.length > 0 && (
+                  <div className="text-center py-12 text-slate-400 font-medium border-2 border-dashed border-slate-200 rounded-xl">
+                    Please choose a visit to view vitals.
+                  </div>
+                )
+              )}
+            </div>
+          </FormProvider>
         </div>
       </div>
     </div>
@@ -260,9 +263,12 @@ function VitalsForm({ visitId }: { visitId: number }) {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
-      {/*normal body stuff*/}
-      <section className="space-y-4">
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      {/* Body measurements */}
+      <FormSection
+        title="Body Measurements"
+        description="General physical measurements."
+      >
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <RHFInput
             name="height"
@@ -283,10 +289,13 @@ function VitalsForm({ visitId }: { visitId: number }) {
             step="0.1"
           />
         </div>
-      </section>
+      </FormSection>
 
-      {/*Cardiovascular */}
-      <section className="space-y-4">
+      {/* Cardiovascular */}
+      <FormSection
+        title="Cardiovascular"
+        description="Blood pressure and heart rate readings."
+      >
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <RHFInput
             name="systolic"
@@ -300,9 +309,13 @@ function VitalsForm({ visitId }: { visitId: number }) {
           />
           <RHFInput name="heartRate" label="Heart Rate (BPM)" type="number" />
         </div>
-      </section>
+      </FormSection>
 
-      <section className="space-y-4">
+      {/* Blood & metabolic */}
+      <FormSection
+        title="Blood & Metabolic"
+        description="Blood glucose, haemoglobin and diabetes status."
+      >
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <RHFInput
             name="bloodGlucoseFasting"
@@ -329,7 +342,7 @@ function VitalsForm({ visitId }: { visitId: number }) {
             step="0.01"
           />
         </div>
-        <div className="mt-4">
+        <div className="mt-6">
           <RHFRadio
             name="diabetesMellitus"
             label="Diabetes Mellitus History Status Flag"
@@ -339,9 +352,13 @@ function VitalsForm({ visitId }: { visitId: number }) {
             ]}
           />
         </div>
-      </section>
+      </FormSection>
 
-      <section className="space-y-4">
+      {/* Notes & diagnostics */}
+      <FormSection
+        title="Diagnostics & Remarks"
+        description="Urinalysis findings and any additional clinical notes."
+      >
         <div className="space-y-4">
           <RHFTextArea
             name="urineTest"
@@ -354,9 +371,9 @@ function VitalsForm({ visitId }: { visitId: number }) {
             rows={3}
           />
         </div>
-      </section>
+      </FormSection>
 
-      <div className="flex justify-end pt-4 border-t border-slate-100">
+      <div className="flex justify-end pt-2">
         <div className="w-full md:w-44">
           <Button
             type="submit"

--- a/src/pages/vitals/index.tsx
+++ b/src/pages/vitals/index.tsx
@@ -66,7 +66,7 @@ export default function VitalsPage() {
                 <TableCell>
                   <PatientPhoto
                     pictureUrl={patient.patientImageUrl}
-                    className="rounded-full border border-slate-200"
+                    className="rounded-lg border border-slate-200"
                   />
                 </TableCell>
                 <TableCell>


### PR DESCRIPTION
Closes #128 

## Description

Standardises the visit selector header across the Vitals and Vision form pages and cleans up the scattered vitals form layout. Screenshot attached below 

<img width="1111" height="890" alt="Screenshot 2026-08-01 at 5 25 27 PM" src="https://github.com/user-attachments/assets/c998adc3-0603-4394-b091-cbbfade77794" />

## Changes made
- Vitals page now uses same layout as Visiont page: visit dropdown sits on the left and "Filling up vitals form for visit on...." text on the right (follow a 2 column grid that will stack on mobile)
- Group scattered list of inputs into 4 titled sections (Body measurement, Cardiovascular, Blood and Metabolic and Diagnostics and Remarks)
- Add section wrapper info `FormSection` so it can potentially be used between different forms to group related inputs

## Test Plan

- [ ] Navigate to a patient's Vitals page (`/vitals/[id]`) with **multiple** visits, dropdown and confirmation text appear side by side in the header.
- [ ] Resize to mobile → header stacks vertically and section cards remain readable and responsive.
- [ ] Compare against the Vision form page → header layout and confirmation-text placement are visually consistent.
- [ ] Existing tests pass, run `pnpm test` for full sweep