### PR TITLE
171 edit patient details from vitals page

### DIFF
--- a/src/__tests__/lib/utils/patient.test.ts
+++ b/src/__tests__/lib/utils/patient.test.ts
@@ -1,4 +1,8 @@
-import { formatPatientCode, formatPatientId } from "@/lib/utils/patient";
+import {
+  formatPatientCode,
+  formatPatientId,
+  toDateInputValue,
+} from "@/lib/utils/patient";
 
 describe("formatPatientId", () => {
   it("zero-pads ids to 4 digits", () => {
@@ -14,5 +18,24 @@ describe("formatPatientId", () => {
 describe("formatPatientCode", () => {
   it("prefixes the village code when present", () => {
     expect(formatPatientCode("PC", 12)).toBe("PC0012");
+  });
+});
+
+describe("toDateInputValue", () => {
+  it("returns yyyy-MM-dd for an ISO string with a time component", () => {
+    // The shape <input type='date'> requires; the time must be dropped.
+    expect(toDateInputValue("1987-04-10T00:00:00.000Z")).toBe("1987-04-10");
+  });
+
+  it("returns yyyy-MM-dd for a bare date string", () => {
+    expect(toDateInputValue("1987-04-10")).toBe("1987-04-10");
+  });
+
+  it("returns an empty string for an unparseable date string", () => {
+    expect(toDateInputValue("not a date")).toBe("");
+  });
+
+  it("returns an empty string for an invalid Date object", () => {
+    expect(toDateInputValue(new Date(NaN))).toBe("");
   });
 });

--- a/src/__tests__/lib/utils/patient.test.ts
+++ b/src/__tests__/lib/utils/patient.test.ts
@@ -31,8 +31,30 @@ describe("toDateInputValue", () => {
     expect(toDateInputValue("1987-04-10")).toBe("1987-04-10");
   });
 
+  it("preserves single-digit month padding", () => {
+    expect(toDateInputValue("2000-01-05")).toBe("2000-01-05");
+  });
+
+  it("preserves single-digit day padding", () => {
+    expect(toDateInputValue("2000-12-01")).toBe("2000-12-01");
+  });
+
+  it("handles end-of-month dates correctly", () => {
+    expect(toDateInputValue("2024-02-29T00:00:00.000Z")).toBe("2024-02-29");
+  });
+
+  it("handles a Date object", () => {
+    expect(toDateInputValue(new Date("2005-06-15T00:00:00.000Z"))).toBe(
+      "2005-06-15",
+    );
+  });
+
   it("returns an empty string for an unparseable date string", () => {
     expect(toDateInputValue("not a date")).toBe("");
+  });
+
+  it("returns an empty string for an invalid month/day string", () => {
+    expect(toDateInputValue("2000-13-01")).toBe("");
   });
 
   it("returns an empty string for an invalid Date object", () => {

--- a/src/__tests__/server/utils/cloudinary.test.ts
+++ b/src/__tests__/server/utils/cloudinary.test.ts
@@ -1,0 +1,17 @@
+import { extractCloudinaryPublicId } from "@/server/utils/cloudinary";
+
+describe("extractCloudinaryPublicId", () => {
+  it("strips the image/upload/v{version}/ prefix", () => {
+    expect(
+      extractCloudinaryPublicId("image/upload/v1723200000/abc123xyz"),
+    ).toBe("abc123xyz");
+  });
+
+  it("handles any version number length", () => {
+    expect(extractCloudinaryPublicId("image/upload/v42/xyz")).toBe("xyz");
+  });
+
+  it("returns the input unchanged when the prefix is absent", () => {
+    expect(extractCloudinaryPublicId("abc123xyz")).toBe("abc123xyz");
+  });
+});

--- a/src/__tests__/server/utils/cloudinary.test.ts
+++ b/src/__tests__/server/utils/cloudinary.test.ts
@@ -11,7 +11,23 @@ describe("extractCloudinaryPublicId", () => {
     expect(extractCloudinaryPublicId("image/upload/v42/xyz")).toBe("xyz");
   });
 
+  it("preserves folder segments within the public id", () => {
+    expect(
+      extractCloudinaryPublicId("image/upload/v1723200000/patients/photo123"),
+    ).toBe("patients/photo123");
+  });
+
+  it("preserves a file extension in the public id", () => {
+    expect(
+      extractCloudinaryPublicId("image/upload/v1723200000/abc123.jpg"),
+    ).toBe("abc123.jpg");
+  });
+
   it("returns the input unchanged when the prefix is absent", () => {
     expect(extractCloudinaryPublicId("abc123xyz")).toBe("abc123xyz");
+  });
+
+  it("returns an empty string when given an empty string", () => {
+    expect(extractCloudinaryPublicId("")).toBe("");
   });
 });

--- a/src/components/interactive/Modal.tsx
+++ b/src/components/interactive/Modal.tsx
@@ -2,18 +2,31 @@
 
 import { FaWindowClose } from "react-icons/fa";
 import { ReactNode, useEffect, useRef } from "react";
+import { Button } from "@/components/interactive/Button/Button";
 
 export interface ModalProps {
   children: ReactNode;
   onClose?: () => void;
+  /**
+   * Optional header title. When provided, the modal renders a titled header
+   * with a "Close" button (and an "or press Esc" hint) instead of bare corner cross.
+   */
+  title?: string;
 }
 
 /**
- * A modal dialog that renders a centred modal with a backdrop. Contains a close button on the top right of the modal.
+ * A modal dialog that renders a centred modal with a backdrop. When a `title`
+ * is given, it shows a titled header with a Close button; otherwise it shows a
+ * close cross in the top right corner.
  * @param {ReactNode} children - The contents of the modal
  * @param {() => void} [onClose=()=>{}] - The function that runs when the Modal is closed or cancelled
+ * @param {string} [title] - Optional header title; enables the header + Close button layout
  */
-export default function Modal({ children, onClose = () => {} }: ModalProps) {
+export default function Modal({
+  children,
+  onClose = () => {},
+  title,
+}: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
@@ -36,14 +49,28 @@ export default function Modal({ children, onClose = () => {} }: ModalProps) {
       className="inset-0 bg-white rounded-xl shadow-xl p-6 w-full max-w-md fixed flex min-h-60 flex-col justify-between self-center justify-self-center backdrop:fixed backdrop:inset-0 backdrop:bg-black/50"
       onClick={(e) => e.stopPropagation()}
     >
-      <button
-        onClick={() => {
-          onClose();
-        }}
-        className="absolute top-4 right-4"
-      >
-        <FaWindowClose className="text-red-500 text-2xl hover:text-red-700" />
-      </button>
+      {title ? (
+        <div className="flex items-start justify-between gap-4 -mx-6 mb-4 px-6 pb-4 border-b border-slate-100">
+          <h2 className="flex items-center min-h-10 text-2xl font-bold tracking-tight text-slate-900">
+            {title}
+          </h2>
+          <div className="flex flex-col items-end shrink-0">
+            <div className="w-28 flex items-end justify-end">
+              <Button title="Close" colour="red" onClick={() => onClose()} />
+            </div>
+            <span className="mt-1 text-xs text-slate-400">or press Esc</span>
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => {
+            onClose();
+          }}
+          className="absolute top-4 right-4"
+        >
+          <FaWindowClose className="text-red-500 text-2xl hover:text-red-700" />
+        </button>
+      )}
       {children}
     </dialog>
   );

--- a/src/components/interactive/Modal.tsx
+++ b/src/components/interactive/Modal.tsx
@@ -12,6 +12,11 @@ export interface ModalProps {
    * with a "Close" button (and an "or press Esc" hint) instead of bare corner cross.
    */
   title?: string;
+  /**
+   * Optional Tailwind max-width class controlling the modal's width.
+   * Defaults to `max-w-md`.
+   */
+  maxWidthClassName?: string;
 }
 
 /**
@@ -26,6 +31,7 @@ export default function Modal({
   children,
   onClose = () => {},
   title,
+  maxWidthClassName = "max-w-md",
 }: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -46,7 +52,7 @@ export default function Modal({
         onClose();
       }}
       onClose={onClose}
-      className="inset-0 bg-white rounded-xl shadow-xl p-6 w-full max-w-md fixed flex min-h-60 flex-col justify-between self-center justify-self-center backdrop:fixed backdrop:inset-0 backdrop:bg-black/50"
+      className={`inset-0 bg-white rounded-xl shadow-xl p-6 w-full ${maxWidthClassName} fixed flex min-h-60 flex-col justify-between self-center justify-self-center backdrop:fixed backdrop:inset-0 backdrop:bg-black/50`}
       onClick={(e) => e.stopPropagation()}
     >
       {title ? (

--- a/src/components/interactive/Modal.tsx
+++ b/src/components/interactive/Modal.tsx
@@ -2,6 +2,7 @@
 
 import { FaWindowClose } from "react-icons/fa";
 import { ReactNode, useEffect, useRef } from "react";
+import clsx from "clsx";
 import { Button } from "@/components/interactive/Button/Button";
 
 export interface ModalProps {
@@ -52,7 +53,10 @@ export default function Modal({
         onClose();
       }}
       onClose={onClose}
-      className={`inset-0 bg-white rounded-xl shadow-xl p-6 w-full ${maxWidthClassName} fixed flex min-h-60 flex-col justify-between self-center justify-self-center backdrop:fixed backdrop:inset-0 backdrop:bg-black/50`}
+      className={clsx(
+        "inset-0 bg-white rounded-xl shadow-xl p-6 w-full fixed flex min-h-60 flex-col justify-between self-center justify-self-center backdrop:fixed backdrop:inset-0 backdrop:bg-black/50",
+        maxWidthClassName,
+      )}
       onClick={(e) => e.stopPropagation()}
     >
       {title ? (

--- a/src/components/patient/EditPatientForm.tsx
+++ b/src/components/patient/EditPatientForm.tsx
@@ -77,7 +77,13 @@ export default function EditPatientForm({
         },
         onError(error) {
           console.error("Error updating patient:", error);
-          toast.error("Failed to update patient. Please try again.");
+          // Surface a known conflict (duplicate ID) directly; fall back to a
+          // generic message otherwise.
+          toast.error(
+            error.data?.code === "CONFLICT"
+              ? error.message
+              : "Failed to update patient. Please try again.",
+          );
         },
       },
     );

--- a/src/components/patient/EditPatientForm.tsx
+++ b/src/components/patient/EditPatientForm.tsx
@@ -42,6 +42,8 @@ export default function EditPatientForm({
       contactNo: patient.contactNo ?? "",
       gender: patient.gender,
       drugAllergy: patient.drugAllergy,
+      // <input type="date"> only accepts a yyyy-MM-dd value; patient.dateOfBirth
+      // arrives as a Date/ISO string, so convert it or the field renders blank.
       dateOfBirth: toDateInputValue(patient.dateOfBirth),
       hasPoorCard: patient.hasPoorCard,
       hasBS2Card: patient.hasBS2Card,

--- a/src/components/patient/EditPatientForm.tsx
+++ b/src/components/patient/EditPatientForm.tsx
@@ -1,0 +1,163 @@
+import { useForm, FormProvider } from "react-hook-form";
+import { useState } from "react";
+import { WebcamInput } from "@/components/interactive/inputs/WebcamInput";
+import toast from "react-hot-toast";
+import { trpc, RouterOutput } from "@/utils/trpc";
+import { RHFInput } from "@/components/interactive/RHF/RHFInput";
+import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
+import { Button } from "@/components/interactive/Button/Button";
+import { toDateInputValue } from "@/lib/utils/patient";
+
+type Patient = NonNullable<RouterOutput["patientsRouter"]["getById"]>;
+
+type EditPatientFormValues = {
+  name: string;
+  identificationNumber: string;
+  contactNo: string;
+  gender: "male" | "female";
+  drugAllergy: string;
+  dateOfBirth: string;
+  hasPoorCard: boolean;
+  hasBS2Card: boolean;
+  hasSabaiCard: boolean;
+};
+
+/**
+ * Reusable form for editing an existing patient's  details. Prefills
+ * from the given patient and persists via `patientsRouter.update`. Supports
+ * re-capturing the patient's photo; the new image is only sent when the user
+ * actually retakes it, otherwise the existing photo is left untouched.
+ */
+export default function EditPatientForm({
+  patient,
+  onSuccess,
+}: {
+  patient: Patient;
+  onSuccess?: () => void;
+}) {
+  const form = useForm<EditPatientFormValues>({
+    defaultValues: {
+      name: patient.name,
+      identificationNumber: patient.identificationNumber ?? "",
+      contactNo: patient.contactNo ?? "",
+      gender: patient.gender,
+      drugAllergy: patient.drugAllergy,
+      dateOfBirth: toDateInputValue(patient.dateOfBirth),
+      hasPoorCard: patient.hasPoorCard,
+      hasBS2Card: patient.hasBS2Card,
+      hasSabaiCard: patient.hasSabaiCard,
+    },
+  });
+
+  const [imageDetails, setImageDetails] = useState<string | null>(
+    patient.patientImageUrl,
+  );
+
+  const utils = trpc.useUtils();
+  const updateMutation = trpc.patientsRouter.update.useMutation();
+
+  const handleSubmit = (data: EditPatientFormValues) => {
+    // A freshly captured photo is a base64 data URL; the prefilled value is a
+    // remote Cloudinary URL. Only send patientImage when it's a new capture.
+    const isNewPhoto = imageDetails?.startsWith("data:") ?? false;
+
+    updateMutation.mutate(
+      {
+        id: patient.id,
+        ...data,
+        ...(isNewPhoto ? { patientImage: imageDetails! } : {}),
+      },
+      {
+        onSuccess() {
+          utils.patientsRouter.getById.invalidate({ id: patient.id });
+          toast.success("Patient details updated successfully!");
+          onSuccess?.();
+        },
+        onError(error) {
+          console.error("Error updating patient:", error);
+          toast.error("Failed to update patient. Please try again.");
+        },
+      },
+    );
+  };
+
+  return (
+    <FormProvider {...form}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          form.handleSubmit(handleSubmit)(e);
+        }}
+        className="space-y-4"
+      >
+        <div className="grid grid-cols-2 gap-x-6 gap-y-6">
+          <RHFInput name="name" label="Name" type="text" isRequired />
+          <RHFInput
+            name="identificationNumber"
+            label="Identification Number"
+            type="text"
+            isRequired
+          />
+          <RHFInput
+            name="contactNo"
+            label="Contact Number"
+            type="text"
+            isRequired
+          />
+          <RHFDropdown
+            name="gender"
+            label="Gender"
+            dropdownOptions={[
+              { label: "Male", value: "male" },
+              { label: "Female", value: "female" },
+            ]}
+            isRequired
+          />
+          <RHFInput
+            name="drugAllergy"
+            label="Drug Allergy"
+            type="text"
+            isRequired
+          />
+          <RHFInput
+            name="dateOfBirth"
+            label="Date of Birth"
+            type="date"
+            isRequired
+          />
+          <RHFInput
+            name="hasPoorCard"
+            label="Has POOR Card?"
+            type="checkbox"
+            className="flex flex-row-reverse"
+          />
+          <RHFInput
+            name="hasBS2Card"
+            label="Has BS2 Card?"
+            type="checkbox"
+            className="flex flex-row-reverse"
+          />
+          <RHFInput
+            name="hasSabaiCard"
+            label="Has Sabai Card?"
+            type="checkbox"
+            className="flex flex-row-reverse"
+          />
+        </div>
+        <WebcamInput
+          imageDetails={imageDetails}
+          setImageDetails={setImageDetails}
+        />
+
+        <div className="flex gap-3 mt-6 justify-center">
+          <Button
+            type="submit"
+            disabled={updateMutation.isPending}
+            colour="emerald"
+            title={updateMutation.isPending ? "Saving..." : "Save Changes"}
+          />
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/lib/utils/facialRecognition.ts
+++ b/src/lib/utils/facialRecognition.ts
@@ -1,12 +1,14 @@
 import {
   IndexFacesCommand,
   SearchFacesByImageCommand,
+  DeleteFacesCommand,
   RekognitionClient,
   SearchFacesByImageCommandInput,
   SearchFacesByImageCommandOutput,
   Image,
   IndexFacesCommandInput,
   IndexFacesCommandOutput,
+  DeleteFacesCommandInput,
 } from "@aws-sdk/client-rekognition";
 import env from "@/lib/envVariables";
 
@@ -29,6 +31,25 @@ export async function generateFaceprint(str: string) {
   try {
     const results: IndexFacesCommandOutput = await client.send(command);
     return results.FaceRecords?.[0]?.Face?.FaceId;
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+/**
+ * Removes a faceprint from the AWS Collection.
+ * @param faceId The FaceId of the faceprint to delete.
+ */
+export async function deleteFaceprint(faceId: string) {
+  const input: DeleteFacesCommandInput = {
+    CollectionId: env.COLLECTION_ID,
+    FaceIds: [faceId],
+  };
+
+  const command = new DeleteFacesCommand(input);
+
+  try {
+    await client.send(command);
   } catch (err) {
     console.error(err);
   }

--- a/src/lib/utils/patient.ts
+++ b/src/lib/utils/patient.ts
@@ -29,3 +29,12 @@ export function calculateAge(dateOfBirth: Date) {
 
   return age;
 }
+
+/**
+ * Formats a Date/ISO value into the yyyy-MM-dd string a native date input expects.
+ * Returns an empty string for invalid dates.
+ */
+export function toDateInputValue(dateOfBirth: Date | string) {
+  const date = new Date(dateOfBirth);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);
+}

--- a/src/pages/patient/[id]/index.tsx
+++ b/src/pages/patient/[id]/index.tsx
@@ -5,6 +5,10 @@ import { calculateAge } from "@/lib/utils/patient";
 import { trpc } from "@/utils/trpc";
 import { useRouter } from "next/router";
 import withDefaultLayout from "@/components/layouts/withDefaultLayout";
+import { useState } from "react";
+import Modal from "@/components/interactive/Modal";
+import EditPatientForm from "@/components/patient/EditPatientForm";
+import { Button } from "@/components/interactive/Button/Button";
 
 function parsePatientId(id: string | string[] | undefined) {
   if (typeof id !== "string") {
@@ -18,6 +22,7 @@ function parsePatientId(id: string | string[] | undefined) {
 export default function PatientPage() {
   const router = useRouter();
   const patientId = parsePatientId(router.query.id);
+  const [isEditingPatient, setIsEditingPatient] = useState(false);
 
   const {
     data: patient,
@@ -87,13 +92,31 @@ export default function PatientPage() {
               width={64}
               className="h-16 w-16 rounded-lg object-cover border border-slate-200"
             />
-            <div>
+            <div className="flex-1">
               <h1 className="text-2xl font-semibold text-slate-900">
                 {patient.name}
               </h1>
               <p className="text-slate-600">Simple patient profile details</p>
             </div>
+            <Button
+              title="Edit Patient Details"
+              colour="indigo"
+              onClick={() => setIsEditingPatient(true)}
+              className="shrink-0"
+            />
           </div>
+
+          {isEditingPatient && (
+            <Modal
+              title="Edit Patient Details"
+              onClose={() => setIsEditingPatient(false)}
+            >
+              <EditPatientForm
+                patient={patient}
+                onSuccess={() => setIsEditingPatient(false)}
+              />
+            </Modal>
+          )}
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {details.map((detail) => (

--- a/src/pages/vision/update-glasses/[patientId].tsx
+++ b/src/pages/vision/update-glasses/[patientId].tsx
@@ -6,9 +6,7 @@ import Breadcrumbs from "@/components/Breadcrumbs";
 import { trpc } from "@/utils/trpc";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { RHFDropdown } from "@/components/interactive/RHF/RHFDropdown";
-import {
-  EyesightForm,
-} from "@/components/vision/EyesightForm";
+import { EyesightForm } from "@/components/vision/EyesightForm";
 import { EyesightFormValues } from "@/types/eyesight";
 import { formatVisitDate } from "@/lib/utils/visit";
 import { formatPatientId } from "@/lib/utils/patient";

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -19,6 +19,9 @@ import { Button } from "@/components/interactive/Button/Button";
 import toast from "react-hot-toast";
 import { formatVisitDate } from "@/lib/utils/visit";
 import FormSection from "@/components/interactive/inputs/FormSection";
+import { useState } from "react";
+import Modal from "@/components/interactive/Modal";
+import EditPatientForm from "@/components/patient/EditPatientForm";
 
 type VitalsFormValues = {
   height?: string | null;
@@ -42,6 +45,7 @@ export default function PatientVitalsPage() {
   const { id } = router.query;
   const methods = useForm();
   const { setValue } = methods;
+  const [isEditingPatient, setIsEditingPatient] = useState(false);
 
   // Fetch patient
   const { data: patient, isLoading: patientLoading } =
@@ -102,11 +106,30 @@ export default function PatientVitalsPage() {
           ]}
         />
 
-        <div className="flex flex-col mb-8">
+        <div className="flex items-start justify-between gap-4 mb-8">
           <h1 className="text-3xl font-bold text-slate-900">
             Patient Vitals — {patient.name}
           </h1>
+          <Button
+            title="Edit Patient Details"
+            colour="indigo"
+            onClick={() => setIsEditingPatient(true)}
+            className="shrink-0"
+          />
         </div>
+
+        {isEditingPatient && (
+          <Modal
+            title="Edit Patient Details"
+            onClose={() => setIsEditingPatient(false)}
+            maxWidthClassName="max-w-2xl"
+          >
+            <EditPatientForm
+              patient={patient}
+              onSuccess={() => setIsEditingPatient(false)}
+            />
+          </Modal>
+        )}
         <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
           <FormProvider {...methods}>
             <div className="p-6 border-b border-slate-100 bg-slate-50/50">

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -378,10 +378,7 @@ function VitalsForm({ visitId }: { visitId: number }) {
       </FormSection>
 
       {/* Urinalysis */}
-      <FormSection
-        title="Urinalysis"
-        description="Urine test findings."
-      >
+      <FormSection title="Urinalysis" description="Urine test findings.">
         <RHFTextArea
           name="urineTest"
           label="Urinalysis Diagnostics (Leukocytes, Nitrites, Protein notes)"

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -200,6 +200,7 @@ export const patientsRouter = router({
         id: zfd.numeric(z.number().int()), // ID must be included for updates
         name: zfd.text(z.string().optional()),
         identificationNumber: zfd.text(z.string().optional()),
+        contactNo: zfd.text(z.string().optional()),
         gender: zfd.text(z.enum(genderEnum.enumValues).optional()),
         dateOfBirth: zfd.text(z.coerce.date().optional()),
         drugAllergy: zfd.text(z.string().optional()),

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -10,7 +10,7 @@ import { patients, genderEnum, visits } from "@/db/schema/patients";
 import { villageCodes } from "@/db/schema/villageCodes";
 import serverEnv from "@/lib/envVariables";
 import { TRPCError } from "@trpc/server";
-import { eq, desc, inArray, isNotNull } from "drizzle-orm";
+import { eq, and, ne, desc, inArray, isNotNull } from "drizzle-orm";
 import {
   generateFaceprint,
   searchFaceprint,
@@ -216,6 +216,31 @@ export const patientsRouter = router({
     )
     .mutation(async ({ input }) => {
       const { id, patientImage, ...updateData } = input;
+
+      // Reject an identificationNumber that already belongs to a different
+      // patient. This is the guard against creating duplicate IDs via updates.
+      if (updateData.identificationNumber) {
+        const [conflict] = await db
+          .select({ id: patients.id })
+          .from(patients)
+          .where(
+            and(
+              eq(
+                patients.identificationNumber,
+                updateData.identificationNumber,
+              ),
+              ne(patients.id, id),
+            ),
+          )
+          .limit(1);
+
+        if (conflict) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Another patient already has this identification number.",
+          });
+        }
+      }
 
       let imageUpdate: {
         patientImagePublicId?: string;

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -284,13 +284,42 @@ export const patientsRouter = router({
         }
 
         // Best-effort cleanup of the replaced assets.
+        // Only delete if no other patient still references the same asset (image or faceprint)
         if (existing?.patientImagePublicId) {
-          await deleteFromCloudinary(existing.patientImagePublicId).catch(
-            (err) => console.error("Failed to delete old patient image:", err),
-          );
+          const [sharedImage] = await db
+            .select({ id: patients.id })
+            .from(patients)
+            .where(
+              and(
+                ne(patients.id, id),
+                eq(
+                  patients.patientImagePublicId,
+                  existing.patientImagePublicId,
+                ),
+              ),
+            )
+            .limit(1);
+          if (!sharedImage) {
+            await deleteFromCloudinary(existing.patientImagePublicId).catch(
+              (err) =>
+                console.error("Failed to delete old patient image:", err),
+            );
+          }
         }
         if (rekognitionFaceId && existing?.rekognitionFaceId) {
-          await deleteFaceprint(existing.rekognitionFaceId);
+          const [sharedFace] = await db
+            .select({ id: patients.id })
+            .from(patients)
+            .where(
+              and(
+                ne(patients.id, id),
+                eq(patients.rekognitionFaceId, existing.rekognitionFaceId),
+              ),
+            )
+            .limit(1);
+          if (!sharedFace) {
+            await deleteFaceprint(existing.rekognitionFaceId);
+          }
         }
       }
 

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { uploadToCloudinary } from "@/server/utils/cloudinary";
+import {
+  uploadToCloudinary,
+  deleteFromCloudinary,
+} from "@/server/utils/cloudinary";
 import { router, protectedProcedure } from "@/server/trpc";
 import { db } from "@/db/drizzle";
 import { patients, genderEnum, visits } from "@/db/schema/patients";
@@ -11,6 +14,7 @@ import { eq, desc, inArray, isNotNull } from "drizzle-orm";
 import {
   generateFaceprint,
   searchFaceprint,
+  deleteFaceprint,
   dataUrlToFile,
 } from "@/lib/utils/facialRecognition";
 
@@ -212,17 +216,57 @@ export const patientsRouter = router({
     )
     .mutation(async ({ input }) => {
       const { id, patientImage, ...updateData } = input;
-      let patientImagePublicId;
+
+      let imageUpdate: {
+        patientImagePublicId?: string;
+        rekognitionFaceId?: string;
+      } = {};
+
+      // Client sends a new base64 image (recapture)
       if (patientImage) {
-        const patientImage: File = dataUrlToFile(
-          input.patientImage!, // Temporarily add non-null operator until later refactoring
-          `${input.name}.jpg`,
+        // Reads patient's current Cloudinary image id and Rekognition face id before overwriting them
+        const [existing] = await db
+          .select({
+            patientImagePublicId: patients.patientImagePublicId,
+            rekognitionFaceId: patients.rekognitionFaceId,
+          })
+          .from(patients)
+          .where(eq(patients.id, id))
+          .limit(1);
+
+        const imageFile: File = dataUrlToFile(
+          patientImage,
+          `${input.name ?? id}.jpg`,
         );
-        patientImagePublicId = await uploadToCloudinary(patientImage);
+
+        const [patientImagePublicId, rekognitionFaceId] = await Promise.all([
+          uploadToCloudinary(imageFile),
+          generateFaceprint(patientImage),
+        ]);
+        imageUpdate = { patientImagePublicId, rekognitionFaceId };
+
+        // No faceprint means the new photo wasn't indexed; keep the old one so
+        // the patient stays searchable by face.
+        if (!rekognitionFaceId) {
+          console.warn(
+            `Faceprint not generated for patient ${id}; new photo is not searchable by face. Keeping previous faceprint.`,
+          );
+        }
+
+        // Best-effort cleanup of the replaced assets.
+        if (existing?.patientImagePublicId) {
+          await deleteFromCloudinary(existing.patientImagePublicId).catch(
+            (err) => console.error("Failed to delete old patient image:", err),
+          );
+        }
+        if (rekognitionFaceId && existing?.rekognitionFaceId) {
+          await deleteFaceprint(existing.rekognitionFaceId);
+        }
       }
+
       const [result] = await db
         .update(patients)
-        .set({ ...updateData, patientImagePublicId })
+        .set({ ...updateData, ...imageUpdate })
         .where(eq(patients.id, id))
         .returning();
 

--- a/src/server/routers/patients_router.ts
+++ b/src/server/routers/patients_router.ts
@@ -217,6 +217,11 @@ export const patientsRouter = router({
     .mutation(async ({ input }) => {
       const { id, patientImage, ...updateData } = input;
 
+      if (updateData.identificationNumber !== undefined) {
+        updateData.identificationNumber =
+          updateData.identificationNumber.trim();
+      }
+
       // Reject an identificationNumber that already belongs to a different
       // patient. This is the guard against creating duplicate IDs via updates.
       if (updateData.identificationNumber) {

--- a/src/server/utils/cloudinary.ts
+++ b/src/server/utils/cloudinary.ts
@@ -20,3 +20,14 @@ export async function uploadToCloudinary(image: File) {
 
   return `image/upload/v${uploaded.version}/${uploaded.public_id}`;
 }
+
+/**
+ * Deletes an image from Cloudinary given the stored public id path
+ * (the `image/upload/v{version}/{public_id}` value produced by
+ * {@link uploadToCloudinary}). The leading `image/upload/v{version}/` prefix is
+ * stripped to recover the bare public id that the destroy API expects.
+ */
+export async function deleteFromCloudinary(publicIdPath: string) {
+  const publicId = publicIdPath.replace(/^image\/upload\/v\d+\//, "");
+  await cloudinary.uploader.destroy(publicId, { resource_type: "image" });
+}

--- a/src/server/utils/cloudinary.ts
+++ b/src/server/utils/cloudinary.ts
@@ -22,12 +22,22 @@ export async function uploadToCloudinary(image: File) {
 }
 
 /**
+ * Recovers the bare public id (what the destroy API expects) from the stored
+ * `image/upload/v{version}/{public_id}` path produced by {@link uploadToCloudinary}.
+ * Any folder segments in the public id are preserved; only the
+ * `image/upload/v{version}/` prefix is stripped. If the prefix isn't present
+ * (unexpected format), the input is returned unchanged.
+ */
+export function extractCloudinaryPublicId(publicIdPath: string): string {
+  return publicIdPath.replace(/^image\/upload\/v\d+\//, "");
+}
+
+/**
  * Deletes an image from Cloudinary given the stored public id path
  * (the `image/upload/v{version}/{public_id}` value produced by
- * {@link uploadToCloudinary}). The leading `image/upload/v{version}/` prefix is
- * stripped to recover the bare public id that the destroy API expects.
+ * {@link uploadToCloudinary}).
  */
 export async function deleteFromCloudinary(publicIdPath: string) {
-  const publicId = publicIdPath.replace(/^image\/upload\/v\d+\//, "");
+  const publicId = extractCloudinaryPublicId(publicIdPath);
   await cloudinary.uploader.destroy(publicId, { resource_type: "image" });
 }


### PR DESCRIPTION
Closes #171 

## Description

Adds the ability to edit an existing patient's details (including re-capturing their photo) from both the patient profile page and the vitals page. Previously patient records were create-only; there was no way to fix bad typo or replace bad photo after registration of patients

## Changes
### 1. Edit Form component
- New `EditPatientForm` component, prefilled from the patient and persisted via patientsRouter.update. Rendered in a modal from both `patient/[id]` and `vitals/[id]`.
- Two-column field layout; modal widened to `max-w-2xl` via a new optional `maxWidthClassName` prop on Modal (default unchanged for every other modal used).
- Date of birth is normalized to yyyy-MM-dd (toDateInputValue) so the native date input prefills instead of rendering blank

### 2. Photo recapture
- WebcamInput wired into the edit form. The new image is only sent when the user actually retakes it; otherwise existing photo is untouched.
- On the backend, update now uploads the new image and regenerates the Rekognition faceprint in parallel via `Promise.all`, so face-search stays in sync with the new photo.
- Old Cloudinary image and Rekognition faceprint are cleaned up (best-effort delivery). New helpers: `deleteFromCloudinary`, `deleteFaceprint`.

### 3. Duplicate ID protection
- update procedure rejects an id that already belongs to a different patient (CONFLICT), and the form surfaces that message in a toast.

## Test plan
Manual — edit flow
- [x] From `patient/[id]`, click "Edit Patient Details" → modal opens prefilled, DOB shows the correct date.
- [x] Same from `vitals/[id]`.
- [x] Edit name/contact/gender/allergy/DOB/cards → Save → toast success, values persist after refetch.

Manual — photo recapture
- [ ] Open edit, don't touch the photo, Save → existing photo unchanged in Cloudinary.
- [ ] Retake photo → Save → new image shows on the profile.
- [ ] After recapture, verify the patient is still found by face search (verify faceprint regenerated).
