### PR TITLE
96 rhfinput validation

### DIFF
--- a/src/__tests__/components/interactive/RHF/RHFInput.test.tsx
+++ b/src/__tests__/components/interactive/RHF/RHFInput.test.tsx
@@ -58,6 +58,28 @@ describe("RHFInput numeric validation", () => {
     expect(onKeyDown).toHaveBeenCalled();
   });
 
+  it("blocks pasting text containing 'e'/'E'", async () => {
+    const user = userEvent.setup();
+    renderNumberInput();
+
+    const input = screen.getByLabelText(/Amount/) as HTMLInputElement;
+    input.focus();
+    await user.paste("1e5");
+
+    expect(input.value).toBe("");
+  });
+
+  it("allows pasting purely numeric text", async () => {
+    const user = userEvent.setup();
+    renderNumberInput();
+
+    const input = screen.getByLabelText(/Amount/) as HTMLInputElement;
+    input.focus();
+    await user.paste("123");
+
+    expect(input.value).toBe("123");
+  });
+
   it("does not block letters for text inputs", async () => {
     const user = userEvent.setup();
     render(

--- a/src/__tests__/components/interactive/RHF/RHFInput.test.tsx
+++ b/src/__tests__/components/interactive/RHF/RHFInput.test.tsx
@@ -1,0 +1,74 @@
+import { RHFInput } from "@/components/interactive/RHF/RHFInput";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+/** Wraps children in a FormProvider, as RHFInput requires a form context. */
+function FormWrapper({ children }: { children: ReactNode }) {
+  const methods = useForm();
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+function renderNumberInput() {
+  return render(
+    <FormWrapper>
+      <RHFInput name="amount" label="Amount" type="number" />
+    </FormWrapper>,
+  );
+}
+
+describe("RHFInput numeric validation", () => {
+  it("blocks the 'e' character on keydown", async () => {
+    const user = userEvent.setup();
+    renderNumberInput();
+
+    const input = screen.getByLabelText(/Amount/) as HTMLInputElement;
+    await user.type(input, "12e3");
+
+    expect(input.value).toBe("123");
+  });
+
+  it("blocks the 'E' character on keydown", async () => {
+    const user = userEvent.setup();
+    renderNumberInput();
+
+    const input = screen.getByLabelText(/Amount/) as HTMLInputElement;
+    await user.type(input, "1E2");
+
+    expect(input.value).toBe("12");
+  });
+
+  it("still calls a user-provided onKeyDown handler", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    render(
+      <FormWrapper>
+        <RHFInput
+          name="amount"
+          label="Amount"
+          type="number"
+          onKeyDown={onKeyDown}
+        />
+      </FormWrapper>,
+    );
+
+    await user.type(screen.getByLabelText(/Amount/), "5");
+
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  it("does not block letters for text inputs", async () => {
+    const user = userEvent.setup();
+    render(
+      <FormWrapper>
+        <RHFInput name="note" label="Note" type="text" />
+      </FormWrapper>,
+    );
+
+    const input = screen.getByLabelText(/Note/) as HTMLInputElement;
+    await user.type(input, "NKDA");
+
+    expect(input.value).toBe("NKDA");
+  });
+});

--- a/src/components/interactive/RHF/RHFInput.tsx
+++ b/src/components/interactive/RHF/RHFInput.tsx
@@ -14,13 +14,7 @@ type RHFInputProps = {
   >["className"];
   registerOptions?: RegisterOptions;
   type:
-    | "text"
-    | "email"
-    | "password"
-    | "number"
-    | "date"
-    | "color"
-    | "checkbox";
+    "text" | "email" | "password" | "number" | "date" | "color" | "checkbox";
 } & DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
 /**
@@ -71,6 +65,20 @@ export function RHFInput({
   const fieldError = formState?.errors?.[name];
 
   const isCheckbox = type === "checkbox";
+  const isNumber = type === "number";
+
+  // For numeric inputs, block the exponent characters that <input type="number">
+  // accepts but that we don't want ("e"/"E") on keydown.
+  const blockedNumberKeys = ["e", "E"];
+
+  const handleNumberKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (blockedNumberKeys.includes(event.key)) {
+      event.preventDefault();
+    }
+    props.onKeyDown?.(event);
+  };
 
   if (isCheckbox) {
     return (
@@ -106,6 +114,9 @@ export function RHFInput({
         type={type}
         {...registerProps}
         {...props}
+        {...(isNumber && {
+          onKeyDown: handleNumberKeyDown,
+        })}
         className={clsx([
           "border border-gray-300 rounded bg-white px-3 py-2 transition focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-blue-400",
           fieldError &&

--- a/src/components/interactive/RHF/RHFInput.tsx
+++ b/src/components/interactive/RHF/RHFInput.tsx
@@ -80,6 +80,14 @@ export function RHFInput({
     props.onKeyDown?.(event);
   };
 
+  const handleNumberPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    const pastedText = event.clipboardData.getData("text");
+    if (/[eE]/.test(pastedText)) {
+      event.preventDefault();
+    }
+    props.onPaste?.(event);
+  };
+
   if (isCheckbox) {
     return (
       <label
@@ -116,6 +124,7 @@ export function RHFInput({
         {...props}
         {...(isNumber && {
           onKeyDown: handleNumberKeyDown,
+          onPaste: handleNumberPaste,
         })}
         className={clsx([
           "border border-gray-300 rounded bg-white px-3 py-2 transition focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-blue-400",


### PR DESCRIPTION
Closes #96.

## Description 

- `<input type="number">` natively accepts scientific-notation characters (`e`, `E`), which lets users enter not so meaningful values like`12e3` into numeric medical fields (height, weight, heart rate, medication quantities). 

## Changes

- `RHFInput.tsx`: when `type="number"`, attach an `onKeyDown` for this. Any caller-supplied `onKeyDown`is still forwarded.
- Added `RHFInput.test.tsx` covering the numeric blocking.

## Test plan

**Automated**
- [ ] `npx vitest run src/__tests__/components/interactive/RHF/RHFInput.test.tsx` — 4 tests pass

**Manual**
- [ ] Verify in pages where `type="number"` is being used with `RHFInput`


