### PR TITLE
184 allow decimal values in vitals form numeric fields

### DIFF
--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -264,12 +264,23 @@ function VitalsForm({ visitId }: { visitId: number }) {
       {/*normal body stuff*/}
       <section className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <RHFInput name="height" label="Height (cm)" type="number" />
-          <RHFInput name="weight" label="Weight (kg)" type="number" />
+          <RHFInput
+            name="height"
+            label="Height (cm)"
+            type="number"
+            step="0.1"
+          />
+          <RHFInput
+            name="weight"
+            label="Weight (kg)"
+            type="number"
+            step="0.01"
+          />
           <RHFInput
             name="temperature"
             label="Body Temperature (°C)"
             type="number"
+            step="0.1"
           />
         </div>
       </section>
@@ -297,17 +308,25 @@ function VitalsForm({ visitId }: { visitId: number }) {
             name="bloodGlucoseFasting"
             label="Fasting Blood Glucose (mmol/L)"
             type="number"
+            step="0.01"
           />
           <RHFInput
             name="bloodGlucoseNonFasting"
             label="Non-Fasting Blood Glucose (mmol/L)"
             type="number"
+            step="0.01"
           />
-          <RHFInput name="hba1c" label="HbA1c Level (%)" type="number" />
+          <RHFInput
+            name="hba1c"
+            label="HbA1c Level (%)"
+            type="number"
+            step="0.01"
+          />
           <RHFInput
             name="hemocueCount"
             label="Hemocue Hemoglobin Count (g/dL)"
             type="number"
+            step="0.01"
           />
         </div>
         <div className="mt-4">

--- a/src/server/routers/vitals_router.ts
+++ b/src/server/routers/vitals_router.ts
@@ -27,26 +27,47 @@ const selectVitalsFields = {
 };
 
 /**
+ * Validator for PostgreSQL `numeric` column. Validates that the value is a
+ * number at the given precision (`step` mirrors the form input's `step`), then
+ * serializes back to the string that Drizzle `numeric` columns expect.
+ * `label` is used in error messages
+ *
+ */
+const numericColumn = (label: string, { step }: { step: number }) =>
+  z.coerce
+    .number({ error: `${label} must be a number` })
+    .multipleOf(step, { error: `${label} must be in steps of ${step}` })
+    .transform((n) => n.toString())
+    .optional();
+
+/** Validator for an integer column. */
+const integerColumn = (label: string) =>
+  z.coerce
+    .number({ error: `${label} must be a number` })
+    .int({ error: `${label} must be a whole number` })
+    .optional();
+
+/**
  * Input validation schema for creating vitals records.
- * Uses z.coerce.string() for PostgreSQL numeric fields.
+ * Numeric fields validate precision; the `step` values mirror the form input
+ * `step` and the DB `numeric(_, 2)` scale.
  */
 const createVitalsInput = z.object({
-  // `.nullish()` (not `.optional()`) so the form can send `null` to explicitly
-  // clear a field on update; `undefined` is skipped by Drizzle and would leave
-  // the previous value untouched.
-  height: z.coerce.string().nullish(), // cm
-  weight: z.coerce.string().nullish(), // kg
-  temperature: z.coerce.string().nullish(), // °C
-  systolic: z.number().int().nullish(), // mmHg
-  diastolic: z.number().int().nullish(), // mmHg
-  heartRate: z.number().int().nullish(), // bpm
-  hemocueCount: z.coerce.string().nullish(), // g/dL
-  diabetesMellitus: z.boolean().nullish(),
-  urineTest: z.string().nullish(),
-  bloodGlucoseNonFasting: z.coerce.string().nullish(), // mg/dL or mmol/L
-  bloodGlucoseFasting: z.coerce.string().nullish(), // mg/dL or mmol/L
-  hba1c: z.coerce.string().nullish(), // %
-  others: z.string().nullish(),
+  height: numericColumn("Height", { step: 0.1 }), // cm
+  weight: numericColumn("Weight", { step: 0.01 }), // kg
+  temperature: numericColumn("Body temperature", { step: 0.1 }), // °C
+  systolic: integerColumn("Systolic blood pressure"), // mmHg
+  diastolic: integerColumn("Diastolic blood pressure"), // mmHg
+  heartRate: integerColumn("Heart rate"), // bpm
+  hemocueCount: numericColumn("Hemocue count", { step: 0.01 }), // g/dL
+  diabetesMellitus: z.boolean().optional(),
+  urineTest: z.string().optional(),
+  bloodGlucoseNonFasting: numericColumn("Non-fasting blood glucose", {
+    step: 0.01,
+  }), // mmol/L
+  bloodGlucoseFasting: numericColumn("Fasting blood glucose", { step: 0.01 }), // mmol/L
+  hba1c: numericColumn("HbA1c", { step: 0.01 }), // %
+  others: z.string().optional(),
   visitId: z.number().int().positive(),
 });
 

--- a/src/server/routers/vitals_router.ts
+++ b/src/server/routers/vitals_router.ts
@@ -31,7 +31,6 @@ const selectVitalsFields = {
  * number at the given precision (`step` mirrors the form input's `step`), then
  * serializes back to the string that Drizzle `numeric` columns expect.
  * `label` is used in error messages
- *
  */
 const numericColumn = (label: string, { step }: { step: number }) =>
   z.coerce

--- a/src/server/routers/vitals_router.ts
+++ b/src/server/routers/vitals_router.ts
@@ -59,14 +59,14 @@ const createVitalsInput = z.object({
   diastolic: integerColumn("Diastolic blood pressure"), // mmHg
   heartRate: integerColumn("Heart rate"), // bpm
   hemocueCount: numericColumn("Hemocue count", { step: 0.01 }), // g/dL
-  diabetesMellitus: z.boolean().optional(),
-  urineTest: z.string().optional(),
+  diabetesMellitus: z.boolean().nullable().optional(),
+  urineTest: z.string().nullable().optional(),
   bloodGlucoseNonFasting: numericColumn("Non-fasting blood glucose", {
     step: 0.01,
   }), // mmol/L
   bloodGlucoseFasting: numericColumn("Fasting blood glucose", { step: 0.01 }), // mmol/L
   hba1c: numericColumn("HbA1c", { step: 0.01 }), // %
-  others: z.string().optional(),
+  others: z.string().nullable().optional(),
   visitId: z.number().int().positive(),
 });
 


### PR DESCRIPTION
Closes #184 

## Description
- Fixes bug in the patient vitals form where numeric fields rejected decimal values. Because the inputs rendered as `<input type="number">` with the default `step="1"`, entering a body temperature of `37.5 °C` failed with the browser error *"Please enter a valid value. The two nearest valid values are 37 and 38."* This forced staff to round measurements that clinically require decimals. Ideally there should be no rounding for such fields

## Changes

Frontend — `src/pages/vitals/[id]/index.tsx`
- Added a per-field `step` to the numeric inputs so decimals are accepted at the correct precision:
  - `0.1` — Height (cm), Body Temperature (°C)
  - `0.01` — Weight (kg), Fasting/Non-Fasting Blood Glucose (mmol/L), HbA1c (%), Hemocue Count (g/dL)
  - Systolic, Diastolic, and Heart Rate are remain whole numbers.

Backend — `src/server/routers/vitals_router.ts`
- Added `numericColumn` / `integerColumn` helpers that validate each field's type and precision server-side (precision mirrors the form `step`), then serialize numeric values back to the string Drizzle `numeric` columns expect.
- Error messages name the offending field

<img width="618" height="183" alt="Screenshot 2026-08-09 at 2 59 20 PM" src="https://github.com/user-attachments/assets/979b5f1d-effe-4fdd-98c4-ff1b01cede62" />

