### PR TITLE
186  allow clearing of vitals form fields 

### DIFF
--- a/src/__tests__/pages/vitals/[id]/index.test.tsx
+++ b/src/__tests__/pages/vitals/[id]/index.test.tsx
@@ -1,7 +1,7 @@
 import PatientVitalsPage from "@/pages/vitals/[id]";
 import { trpc } from "@/utils/trpc";
 import { Toaster, toast } from "react-hot-toast";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { assertLoadingSpinner } from "@/__tests__/utils/helper-functions";
 import { useRouter } from "next/router";
@@ -182,6 +182,33 @@ describe("VitalsForm", () => {
       const toast = screen.getByRole("status");
       expect(toast).toBeInTheDocument();
       expect(toast.textContent).toBe("Vitals saved successfully!");
+    });
+  });
+
+  test("clears a previously-saved field by sending null on update", async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    mockTrpc.vitalsRouter.getByVisitId.useQuery.mockReturnValue({
+      data: MOCK_VITALS,
+      isLoading: false,
+    });
+    mockTrpc.vitalsRouter.updateByVisitId.useMutation.mockReturnValue({
+      mutate,
+      isPending: false,
+    });
+
+    renderPage();
+
+    const tempInput = await screen.findByDisplayValue(MOCK_VITALS.temperature);
+    await user.clear(tempInput);
+
+    fireEvent.submit(tempInput.closest("form")!);
+
+    // A cleared field must persist as null (explicit NULL), not be dropped.
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ temperature: null }),
+      );
     });
   });
 

--- a/src/pages/vitals/[id]/index.tsx
+++ b/src/pages/vitals/[id]/index.tsx
@@ -230,26 +230,26 @@ function VitalsForm({ visitId }: { visitId: number }) {
       return;
     }
 
+    // Send `null` (not `undefined`) for cleared fields so they are explicitly
+    // set to NULL on update — `undefined` is skipped by Drizzle and would leave
+    // the previous value untouched.
     const payload = {
       visitId: visitId,
-      height: data.height || undefined,
-      weight: data.weight || undefined,
-      temperature: data.temperature || undefined,
-      systolic: data.systolic ? Number(data.systolic) : undefined,
-      diastolic: data.diastolic ? Number(data.diastolic) : undefined,
-      heartRate: data.heartRate ? Number(data.heartRate) : undefined,
-      hemocueCount: data.hemocueCount || undefined,
-      diabetesMellitus:
-        data.diabetesMellitus === "true"
-          ? true
-          : data.diabetesMellitus === "false"
-            ? false
-            : undefined,
-      urineTest: data.urineTest || undefined,
-      bloodGlucoseNonFasting: data.bloodGlucoseNonFasting || undefined,
-      bloodGlucoseFasting: data.bloodGlucoseFasting || undefined,
-      hba1c: data.hba1c || undefined,
-      others: data.others || undefined,
+      height: data.height || null,
+      weight: data.weight || null,
+      temperature: data.temperature || null,
+      systolic: data.systolic ? Number(data.systolic) : null,
+      diastolic: data.diastolic ? Number(data.diastolic) : null,
+      heartRate: data.heartRate ? Number(data.heartRate) : null,
+      hemocueCount: data.hemocueCount || null,
+      diabetesMellitus: data.diabetesMellitus
+        ? data.diabetesMellitus === "true"
+        : null,
+      urineTest: data.urineTest || null,
+      bloodGlucoseNonFasting: data.bloodGlucoseNonFasting || null,
+      bloodGlucoseFasting: data.bloodGlucoseFasting || null,
+      hba1c: data.hba1c || null,
+      others: data.others || null,
     };
 
     if (!vitalData) {

--- a/src/server/routers/vitals_router.ts
+++ b/src/server/routers/vitals_router.ts
@@ -31,19 +31,22 @@ const selectVitalsFields = {
  * Uses z.coerce.string() for PostgreSQL numeric fields.
  */
 const createVitalsInput = z.object({
-  height: z.coerce.string().optional(), // cm
-  weight: z.coerce.string().optional(), // kg
-  temperature: z.coerce.string().optional(), // °C
-  systolic: z.number().int().optional(), // mmHg
-  diastolic: z.number().int().optional(), // mmHg
-  heartRate: z.number().int().optional(), // bpm
-  hemocueCount: z.coerce.string().optional(), // g/dL
-  diabetesMellitus: z.boolean().optional(),
-  urineTest: z.string().optional(),
-  bloodGlucoseNonFasting: z.coerce.string().optional(), // mg/dL or mmol/L
-  bloodGlucoseFasting: z.coerce.string().optional(), // mg/dL or mmol/L
-  hba1c: z.coerce.string().optional(), // %
-  others: z.string().optional(),
+  // `.nullish()` (not `.optional()`) so the form can send `null` to explicitly
+  // clear a field on update; `undefined` is skipped by Drizzle and would leave
+  // the previous value untouched.
+  height: z.coerce.string().nullish(), // cm
+  weight: z.coerce.string().nullish(), // kg
+  temperature: z.coerce.string().nullish(), // °C
+  systolic: z.number().int().nullish(), // mmHg
+  diastolic: z.number().int().nullish(), // mmHg
+  heartRate: z.number().int().nullish(), // bpm
+  hemocueCount: z.coerce.string().nullish(), // g/dL
+  diabetesMellitus: z.boolean().nullish(),
+  urineTest: z.string().nullish(),
+  bloodGlucoseNonFasting: z.coerce.string().nullish(), // mg/dL or mmol/L
+  bloodGlucoseFasting: z.coerce.string().nullish(), // mg/dL or mmol/L
+  hba1c: z.coerce.string().nullish(), // %
+  others: z.string().nullish(),
   visitId: z.number().int().positive(),
 });
 


### PR DESCRIPTION
Closes #186 

## Description 
- Fixes a bug where a previously-saved vital measurement could not be cleared. On a visit that already had vitals, blanking a field and saving left the old value in the db. A wrong reading could never be removed, only overwritten.


## Changes
- **`src/pages/vitals/[id]/index.tsx`** — `onSubmit` now sends `null` (not `undefined`) for cleared fields, so they are explicitly written as `NULL`. 
- **`src/server/routers/vitals_router.ts`** — vitals input fields changed from `.optional()` to `.nullish()` so `null` passes validation and reaches Drizzle.
- **`src/__tests__/pages/vitals/[id]/index.test.tsx`** — add test on load existing vitals, clear the temperature field, submit, and assert the update payload contains `temperature: null`.

## Test plan

- [x] Existing vitals test suite passes.
- [ ] Manually: open a visit with saved vitals, clear a field, save, reload => field is empty.